### PR TITLE
Label & synonym capitalization updates

### DIFF
--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -3,7 +3,7 @@ import sys
 from rdflib import Graph, URIRef, RDF, OWL, RDFS, Literal, Namespace, DC
 
 from omim2obo.namespaces import *
-from omim2obo.utils.api_entry import cleanup_label, get_alt_labels, get_pubs, get_mapped_ids
+from omim2obo.utils.api_entry import cleanup_label, cleanup_synonym, get_alt_labels, get_pubs, get_mapped_ids
 from omim2obo.omim_client import OmimClient
 from omim2obo.config import config, DATA_DIR
 from omim2obo.parsers.omim_txt_parser import *
@@ -69,6 +69,7 @@ if __name__ == '__main__':
         if inc_label:
             other_labels += get_alt_labels(inc_label)
 
+        # TODO: #now
         # Labels
         abbrev = label.split(';')[1].strip() if ';' in label else None
         if omim_type == OmimType.HERITABLE_PHENOTYPIC_MARKER:  # %
@@ -85,9 +86,9 @@ if __name__ == '__main__':
         else:
             graph.add((omim_uri, RDFS.label, Literal(cleanup_label(label))))
 
-        graph.add((omim_uri, oboInOwl.hasExactSynonym, Literal(label)))
+        graph.add((omim_uri, oboInOwl.hasExactSynonym, Literal(cleanup_synonym(label))))
         for label in other_labels:
-            graph.add((omim_uri, oboInOwl.hasRelatedSynonym, Literal(label)))
+            graph.add((omim_uri, oboInOwl.hasRelatedSynonym, Literal(cleanup_synonym(label))))
 
     # Gene ID
     gene_map, pheno_map = parse_mim2gene(retrieve_mim_file('mim2gene.txt', DOWNLOAD_TXT_FILES))
@@ -151,9 +152,3 @@ if __name__ == '__main__':
 
     with open(DATA_DIR / 'omim_new.ttl', 'w') as f:
         f.write(graph.serialize(format='turtle'))
-
-
-
-
-
-

--- a/omim2obo/utils/api_entry.py
+++ b/omim2obo/utils/api_entry.py
@@ -12,16 +12,32 @@ def check_version(file_path):
     print(Path(file_path).stat())
 
 
+def cleanup_synonym(synonym):
+    """
+    Reformat to lower case the first character of the string.
+
+    :param synonym: str
+    :return: str
+    """
+    abbrev_with_periods = re.match('^([A-Z]\.){2,}$', synonym)
+    abbrev_without_periods = re.match('^[A-Z]{2,}$', synonym)
+    if abbrev_with_periods or abbrev_without_periods:
+        return synonym
+    else:
+        return synonym[0].lower() + synonym[1:]
+
+
 def cleanup_label(label):
     """
     Reformat the ALL CAPS OMIM labels to something more pleasant to read.
     This will:
     1.  remove the abbreviation suffixes
     2.  convert the roman numerals to integer numbers
-    3.  make the text title case,
-        except for suplied conjunctions/prepositions/articles
-    :param label:
-    :return:
+    3.  make the text title case, w/ exceptions for
+        - supplied conjunctions/prepositions/articles
+        - the first character of the string
+    :param label: str
+    :return: str
     """
     conjunctions = ['and', 'but', 'yet', 'for', 'nor', 'so']
     little_preps = [
@@ -50,8 +66,9 @@ def cleanup_label(label):
                 fixed = ''.join((str(num), suffix))
                 wrd = fixed
 
-        # capitalize first letter
-        wrd = wrd.title()
+        # capitalize first letter, except for first word
+        if i > 1:
+            wrd = wrd.title()
 
         # replace interior conjunctions, prepositions,
         # and articles with lowercase
@@ -61,6 +78,7 @@ def cleanup_label(label):
         fixedwords.append(wrd)
 
     lbl = ' '.join(fixedwords)
+
     # print (label, '-->', lbl)
     return lbl
 


### PR DESCRIPTION
Updates
- Label cleanup: Ensure that the capitalization operation for the first character of label does not occur
- Synonym cleanup: Added this formatting step. Ensured that first character is always lower case, unless the synonym is an acronym.