### PR TITLE
Fixed releases not getting updated, and more

### DIFF
--- a/.github/workflows/buid_and_release.yml
+++ b/.github/workflows/buid_and_release.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build_and_release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -33,8 +33,10 @@ jobs:
   #      format: YYYYMMDD-HH
   #      utcOffset: "+08:00"
         format: YYYY-MM-DD
-    - name: Build
-      run: make automated-release
+    - name: build
+      run: make automated-release-artefacts -B
+    - name: Release
+      run: echo Uploading files as new release.
 # This one wouldn't work unless it was a tag and on-push.
 #      uses: softprops/action-gh-release@v1
 #    - name: Release
@@ -48,4 +50,4 @@ jobs:
         prerelease: false
         files: |
           omim.ttl
-          omim.sssom.tsv
+#          omim.sssom.tsv

--- a/makefile
+++ b/makefile
@@ -1,23 +1,26 @@
-.PHONY: all help install test scrape get-pmids automated-release
+.PHONY: all help install test scrape get-pmids automated-release cleanup
 
 
 # MAIN COMMANDS / GOALS ------------------------------------------------------------------------------------------------
 all: omim.ttl omim.sssom.tsv
-automated-release: omim.ttl
+automated-release-artefacts: omim.ttl
 
 # build: Create new omim.ttl
 omim.ttl:
 	 python3 -m omim2obo
-	 @rm omim.json
+	 make cleanup
 
 omim.sssom.tsv: omim.json
 	sssom parse omim.json -I obographs-json -m data/metadata.sssom.yml -o omim.sssom.tsv
-	@rm omim.json
+	make cleanup
 
 # More commands / goals  -----------------------------------------------------------------------------------------------
 # Create mapping artefact(s)
 omim.json:
 	robot convert -i omim.ttl -o omim.json
+
+cleanup:
+	@rm -f omim.json
 
 # scrape: argument should be in form of YYYY/MM or YYYY/mm
 # @param y: The year. Pass as <FLAG>=<YYYY>, where <FLAG> can be y, yr, year, or YYYY.
@@ -51,7 +54,7 @@ help:
 	@echo "----------------------------------------"
 	@echo "all"
 	@echo "Creates all release artefacts.\n"
-	@echo "automated-release"
+	@echo "automated-release-artefacts"
 	@echo "Creates all release artefacts that are currently easy to handle by a GitHub Action automated release. omim.sssom.tsv is excluded because of robot dependency. \n"
 	@echo "omim.ttl"
 	@echo "Creates main release artefact: omim.ttl\n"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Babel==2.9.1
 backports.entry-points-selectable==1.1.0
 beautifulsoup4==4.9.3
 bonobo==0.6.4
-certifi==2021.5.30
+certifi==2022.12.7
 charset-normalizer==2.0.4
 click==8.1.2
 colorama==0.4.4
@@ -24,7 +24,7 @@ imagesize==1.3.0
 importlib-metadata==4.11.3
 isodate==0.6.0
 Jinja2==2.11.3
-joblib==1.1.0
+joblib==1.1.1
 json-flattener==0.1.9
 jsonasobj2==1.0.4
 jsonschema==4.4.0
@@ -32,7 +32,7 @@ linkml-runtime==1.2.7
 MarkupSafe==2.0.1
 mondrian==0.8.1
 networkx==2.8
-numpy==1.21.5
+numpy==1.22.0
 packaging==19.2
 pandas==1.3.5
 pandasql==0.7.3
@@ -51,7 +51,7 @@ pytz==2021.1
 PyYAML==5.4.1
 rdflib==6.1.1
 recommonmark==0.7.1
-requests==2.26.0
+requests==2.31.0
 scikit-learn==1.0.2
 scipy==1.8.0
 six==1.16.0


### PR DESCRIPTION
**Updates**
    - Bugfix: GitHub action workflow was not creating a new release because -B flag missing to force creation of artefacts that already exist.
    - Bugfix: In cleanup step, now doesn't error if file doesn't exist.
    - Update: Changed goal name to be less ambiguous
    - Update: Updated GitHub action workflow steps to be clearer.
    - Security: Upgraded dependencies to fix several security flaws alerted by dependabot.