### PR TITLE
ODK in GitHub action

### DIFF
--- a/.github/workflows/buid_and_release.yml
+++ b/.github/workflows/buid_and_release.yml
@@ -6,48 +6,41 @@ name: Build and release
 on:
   schedule:
     - cron: "0 0 * * 0"  # weekly on Sunday at midnight
-#    - cron: '0 0 * * *'  # every day at midnight
-#    - cron: "0 0 1 * *"  # monthly
   workflow_dispatch:
 
 jobs:
   build_and_release:
     runs-on: ubuntu-latest
+    container: obolibrary/odkfull:v1.4.1
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
     - name: Install
       run: |
-        python -m pip install --upgrade pip
         make install
     - name: Create .env file
       run: |
-        echo -en "API_KEY=${{ secrets.API_KEY }}" > .env
+        echo "API_KEY=${{ secrets.API_KEY }}" > .env
     - name: Get current time
       uses: josStorer/get-current-time@v2.0.2
       id: current-time
       with:
-  #      format: YYYYMMDD-HH
-  #      utcOffset: "+08:00"
         format: YYYY-MM-DD
     - name: build
-      run: make automated-release-artefacts -B
+      # TODO: change to make all when fixed: https://github.com/monarch-initiative/omim/issues/92
+      run: |
+        make automated-release-artefacts
+#        make all
+
+
     - name: Release
       run: echo Uploading files as new release.
-# This one wouldn't work unless it was a tag and on-push.
-#      uses: softprops/action-gh-release@v1
-#    - name: Release
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
-# Apparently, GITHUB_TOKEN is auto-created: https://dev.to/github/the-githubtoken-in-github-actions-how-it-works-change-permissions-customizations-3cgp
-# ...even though I don't see it here: https://github.com/monarch-initiative/omim/settings/secrets/actions
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "${{ steps.current-time.outputs.formattedTime }}"
-#        title: "My Title"
+        title: "${{ steps.current-time.outputs.formattedTime }}"
         prerelease: false
+        # TODO: include omim.sssom.tsv when fixed: https://github.com/monarch-initiative/omim/issues/92
         files: |
           omim.ttl
 #          omim.sssom.tsv

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: all help install test scrape get-pmids automated-release cleanup
+.PHONY: all help install test scrape get-pmids automated-release-artefacts cleanup
 
 
 # MAIN COMMANDS / GOALS ------------------------------------------------------------------------------------------------

--- a/omim2obo/config.py
+++ b/omim2obo/config.py
@@ -1,9 +1,11 @@
+"""Configuration"""
 from pathlib import Path
 import yaml
 from dotenv import dotenv_values
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
 DATA_DIR = ROOT_DIR / 'data'
+ENV_PATH = ROOT_DIR / '.env'
 
 with open(DATA_DIR / 'dipper/GLOBAL_TERMS.yaml') as file:
     GLOBAL_TERMS = yaml.safe_load(file)
@@ -11,4 +13,4 @@ with open(DATA_DIR / 'dipper/GLOBAL_TERMS.yaml') as file:
 with open(DATA_DIR / 'dipper/curie_map.yaml') as file:
     CURIE_MAP = yaml.safe_load(file)
 
-config = dotenv_values(ROOT_DIR / '.env')
+CONFIG = dotenv_values(ENV_PATH)

--- a/omim2obo/parsers/omim_txt_parser.py
+++ b/omim2obo/parsers/omim_txt_parser.py
@@ -12,7 +12,7 @@ import re
 import pandas as pd
 # from rdflib import URIRef
 
-from omim2obo.config import config, DATA_DIR
+from omim2obo.config import CONFIG, DATA_DIR
 from omim2obo.namespaces import RO
 from omim2obo.omim_type import OmimType
 
@@ -69,7 +69,8 @@ def get_mim_file(file_name: str, download=False, return_df=False) -> Union[List[
     mim_file_tsv_path: str = str(mim_file_path).replace('.txt', '.tsv')
 
     if download:
-        url = f'https://data.omim.org/downloads/{config["API_KEY"]}/{file_name}'
+        print(f'Downloading {file_name} from OMIM...')
+        url = f'https://data.omim.org/downloads/{CONFIG["API_KEY"]}/{file_name}'
         # todo: This doesn't work for genemap2.txt. But does the previous URL work? If so, why not just use that?
         if file_name == 'mim2gene.txt':
             url = f'https://omim.org/static/omim/data/{file_name}'

--- a/tests/omim2obo/parsers/test_omim_entry_parser.py
+++ b/tests/omim2obo/parsers/test_omim_entry_parser.py
@@ -1,6 +1,6 @@
 from omim2obo.main import CURIE_MAP
 from omim2obo.parsers.omim_entry_parser import *
-from omim2obo.config import ROOT_DIR, config
+from omim2obo.config import ROOT_DIR, CONFIG
 from omim2obo.namespaces import *
 import json
 

--- a/tests/omim2obo/parsers/test_omim_txt_parser.py
+++ b/tests/omim2obo/parsers/test_omim_txt_parser.py
@@ -1,5 +1,5 @@
 from omim2obo.parsers.omim_txt_parser import *
-from omim2obo.config import ROOT_DIR, config
+from omim2obo.config import ROOT_DIR, CONFIG
 
 
 def test_parse_omim_id_1():


### PR DESCRIPTION
## Overview
Setting up ODK for GitHub actions so that we can run in a good environment with all dependencies, e.g. `robot`.

## Updates
ODK-based GitHub Action
    - Update: GH action workflow: (i) now uses ODK container, (ii) Had to change 'echo -en' to plain 'echo' due to some new incompatibility with new ODK environment, (iii) removed some comments; streamlined.
    - Update: Minor updates in a few files; code comments, codestyle, verbosity

## Depends on
- https://github.com/INCATools/ontology-development-kit/issues/888

## Related issues
- #92 
- #97