### PR TITLE
Bug fix: OMIMPS URI prefix

### DIFF
--- a/data/dipper/curie_map.yaml
+++ b/data/dipper/curie_map.yaml
@@ -77,7 +77,7 @@
 # LIDIA seems retired. so these are not resovable                   # Also: http://www.vetsci.usyd.edu.au/lida/
 'LIDA': 'http://sydney.edu.au/vetscience/lida/dogs/search/disorder/'  # Listing of Inherited Disorders in Animals (defunct?)
 'OMIM': 'https://omim.org/entry/'                                    # Online Mendelian Inheritance in Man (human disease and variants)
-'OMIMPS': 'https://www.omim.org/phenotypicSeries/PS'                   # Online Mendelian Inheritance in Man (phenotypes)
+'OMIMPS': 'https://omim.org/phenotypicSeries/PS'                   # Online Mendelian Inheritance in Man (phenotypes)
 'ORPHA': 'http://www.orpha.net/ORDO/Orphanet_'                      # Rare diseases and Orphan drugs
 'PATO': 'http://purl.obolibrary.org/obo/PATO_'                      # Phenotypic Quality Ontology
 'PCO': 'http://purl.obolibrary.org/obo/PCO_'                        # Population and Community Ontology


### PR DESCRIPTION
## Changes
- Update: URI prefix for OMIMPS.

## Additional info
This manifested in the prefix not getting collapsed in omim.ttl. I'm not sure if there were any other consequences aside from that on the `omim` repo side. But I would imagine that having the URL out of sync with what is in `mondo-ingest` is breaking something, though I'm surprised we would not have noticed yet.

Related:
- Depends on this PR: https://github.com/monarch-initiative/mondo-ingest/pull/504
- Build PR for this PR: https://github.com/monarch-initiative/mondo-ingest/pull/520