### PR TITLE
Change HGNC URI prefix

### DIFF
--- a/omim2obo/namespaces.py
+++ b/omim2obo/namespaces.py
@@ -192,7 +192,7 @@ GENATLAS = Namespace('http://genatlas.medecine.univ-paris5.fr/fiche.php?symbol='
 GENBANK = Namespace('http://www.ncbi.nlm.nih.gov/nuccore/')                               # NCBI nucleotide sequences
 # HGNC = Namespace('http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=')        # pre drupal site
 # HGNC = Namespace('https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:')    # HUGO Gene Nomenclature Committee (Human)
-HGNC = Namespace('https://identifiers.org/hgnc/')    # HUGO Gene Nomenclature Committee (Human)
+HGNC = Namespace('http://identifiers.org/hgnc/')    # HUGO Gene Nomenclature Committee (Human)
 HGNC_symbol = Namespace('https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/')    # HUGO Gene Nomenclature Committee (Human)
 IMPC = Namespace('https://www.mousephenotype.org/data/genes/')                             # International Mouse Phenotyping Consortium (MGI:nnn)
 IMPC_PIPE = Namespace('https://www.mousephenotype.org/impress/PipelineInfo?id=')         # <pipeline-key>

--- a/sparql/mondo-omim-genes.sparql
+++ b/sparql/mondo-omim-genes.sparql
@@ -19,7 +19,7 @@ WHERE
         owl:someValuesFrom ?omim_gene
   ] .
   ?omim_gene skos:exactMatch ?hgnc_id .
-  FILTER(STRSTARTS(STR(?hgnc_id), "https://identifiers.org/hgnc/"))
+  FILTER(STRSTARTS(STR(?hgnc_id), "http://identifiers.org/hgnc/"))
   FILTER(STRSTARTS(STR(?mondo_id), "http://purl.obolibrary.org/obo/MONDO_"))
   BIND(REPLACE(STR(?omim_disease), "https://omim.org/entry/", "OMIM:") AS ?omim_disease_xref)
 }


### PR DESCRIPTION
This is what our Mondo ontology imports are using.

I have not tested this - they key is that this will result in omim-genes.tsv to use the http URIs for hgnc identifiers.