### PR TITLE
Bug fix: Multiple abbreviations & incorrect casing

### DIFF
--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -150,7 +150,7 @@ def omim2obo(use_cache: bool = False):
         omim_uri = OMIM[omim_id]
         graph.add((omim_uri, RDF.type, OWL.Class))
 
-        # Deprecated classes ---
+        # - Deprecated classes
         if str(omim_type_and_titles[omim_id][0]) == 'OmimType.OBSOLETE':
             graph.add((omim_uri, OWL.deprecated, Literal(True)))
             if omim_replaced.get(omim_id, None):
@@ -163,7 +163,7 @@ def omim2obo(use_cache: bool = False):
                         graph.add((omim_uri, oboInOwl.consider, OMIM[replaced_mim_num]))
                 continue
 
-        # Non-deprecated ---
+        # - Non-deprecated
         # Parse titles
         omim_type, pref_labels_str, alt_labels, inc_labels = omim_type_and_titles[omim_id]
         other_labels = []
@@ -178,7 +178,7 @@ def omim2obo(use_cache: bool = False):
             other_labels += cleaned_alt_labels
         if inc_labels:
             cleaned_inc_labels, label_endswith_included_inc = get_alt_labels(inc_labels)
-            # other_labels += cleaned_inc_labels  # deactivated 7/2024 in favor of alternative for tagging 'included
+            # other_labels += cleaned_inc_labels  # deactivated 7/2024 in favor of alternative for tagging 'included'
 
         # Special cases depending on OMIM term type
         is_gene = omim_type == OmimType.GENE or omim_type == OmimType.HAS_AFFECTED_FEATURE
@@ -213,7 +213,7 @@ def omim2obo(use_cache: bool = False):
             graph.add((omim_uri, oboInOwl.hasExactSynonym, Literal(label_cleaner.clean(alt_label, abbrev))))
         for abbreviation in pref_symbols:
             graph.add((omim_uri, oboInOwl.hasExactSynonym, Literal(abbreviation)))
-            # - Reify on abbreviations. See: https://github.com/monarch-initiative/omim/issues/2
+            # Reify on abbreviations. See: https://github.com/monarch-initiative/omim/issues/2
             axiom = BNode()
             graph.add((axiom, RDF.type, OWL.Axiom))
             graph.add((axiom, OWL.annotatedSource, omim_uri))

--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -219,7 +219,7 @@ def omim2obo(use_cache: bool = False):
             graph.add((axiom, OWL.annotatedSource, omim_uri))
             graph.add((axiom, OWL.annotatedProperty, oboInOwl.hasExactSynonym))
             graph.add((axiom, OWL.annotatedTarget, Literal(abbreviation)))
-            graph.add((axiom, oboInOwl.hasExactSynonym, MONDONS.abbreviation))
+            graph.add((axiom, OBOINOWL.hasSynonymType, MONDONS.abbreviation))
 
         # Add 'included' entry properties
         for included_label in cleaned_inc_labels:

--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -203,8 +203,9 @@ def omim2obo(use_cache: bool = False):
         else:
             graph.add((omim_uri, RDFS.label, Literal(label_cleaner.clean(pref_title))))
 
-        # todo: .clean() should accept all symbols/abbrevs (preferred, alt, included), else [] instead of str/None
-        #  - See: https://github.com/monarch-initiative/omim/issues/129
+        # todo: .clean()/.cleanup_label() 2nd param `explicit_abbrev` should be List[str] instead of str. And below,
+        #  should pass all symbols/abbrevs from each of preferred, alt, included each time it is called. If no symbols
+        #  for given term, should pass empty list. See: https://github.com/monarch-initiative/omim/issues/129
         abbrev: Union[str, None] = None if not pref_symbols else pref_symbols[0]
 
         # Add synonyms
@@ -222,11 +223,11 @@ def omim2obo(use_cache: bool = False):
             graph.add((axiom, OBOINOWL.hasSynonymType, MONDONS.abbreviation))
 
         # Add 'included' entry properties
+        included_detected_comment = "This term has one or more labels that end with ', INCLUDED'."
+        if label_endswith_included_alt or label_endswith_included_inc:
+            graph.add((omim_uri, RDFS['comment'], Literal(included_detected_comment)))
         for included_label in cleaned_inc_labels:
             graph.add((omim_uri, URIRef(INCLUDED_URI), Literal(label_cleaner.clean(included_label, abbrev))))
-        if label_endswith_included_alt or label_endswith_included_inc:
-            graph.add(
-                (omim_uri, RDFS['comment'], Literal("This term has one or more labels that end with ', INCLUDED'.")))
 
     # Gene ID
     # Why is 'skos:exactMatch' appropriate for disease::gene relationships? - joeflack4 2022/06/06

--- a/omim2obo/parsers/omim_entry_parser.py
+++ b/omim2obo/parsers/omim_entry_parser.py
@@ -165,6 +165,7 @@ def _detect_abbreviations(
     return replacements
 
 
+# todo: explicit_abbrev: Change to List[str]. See: https://github.com/monarch-initiative/omim/issues/129
 def cleanup_label(
         label: str,
         explicit_abbrev: str = None,


### PR DESCRIPTION
resolves #125 
resolves #126

## Changes
Bug fix: Multiple abbreviations & incorrect casing
- When multiple preferred symbols, they were not being handled correctly. This also resulted in some of these symbols being added with incorrect casing.