### PR TITLE
Mondo namespace update

### DIFF
--- a/data/dipper/curie_map.yaml
+++ b/data/dipper/curie_map.yaml
@@ -103,6 +103,7 @@
 'EMAPA': 'http://purl.obolibrary.org/obo/EMAPA_'                    # Mouse gross anatomy and development, timed
 'XAO': 'http://purl.obolibrary.org/obo/XAO_'                        # Xenopus Anatomy and development
 'MONDO': 'http://purl.obolibrary.org/obo/MONDO_'                    # Monarch Disease Ontology
+'MONDONS': 'http://purl.obolibrary.org/obo/mondo#'                  # Monarch Disease Ontology, alternative
 'NCIT': 'http://purl.obolibrary.org/obo/NCIT_'                      # National Cancer Institute Thesaurus
 'SEPIO': 'http://purl.obolibrary.org/obo/SEPIO_'                    # Scientific Evidence and Provenance Information Ontology
 'VIVO': 'http://vivoweb.org/ontology/core#'                         # ontology for representing scholarship


### PR DESCRIPTION
## Updates
Mondo namespace update
- Add missing prefix map / synchronize `curie_map.yaml` with `namespaces.py`. Add missing MONDONS prefix map.

## Background & additional info
I was looking at `omim.ttl` and I expected to see something like `MONDONS` instead of `ns1`, which is what I saw:

```ttl
@prefix HGNC_symbol: <https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/> .
@prefix IAO: <http://purl.obolibrary.org/obo/IAO_> .
@prefix MONDO: <http://purl.obolibrary.org/obo/MONDO_> .
@prefix OMIM: <https://omim.org/entry/> .
@prefix OMIMPS: <https://omim.org/phenotypicSeries/PS> .
...
@prefix ns1: <http://purl.obolibrary.org/obo/mondo#> .
...
ns1:omim_included a owl:AnnotationProperty .
...
OMIM:103100 a owl:Class ;
    ns1:omim_included "holmes-adie syndrome" ;
    ...
```

I made an update to make `curie_map.yaml` consistent with `namespaces.py`:
https://github.com/monarch-initiative/omim/blob/db4ddd2e88a773d1c5743c82529c665edc1a925c/omim2obo/namespaces.py#L251

In `omim.owl`(RDF/XML) this doesn't matter because it uses URIs instead of CURIEs. AFAIK, this doesn't have any effect that matters other than consistency when looking at `omim.ttl`, which is not a release file. But I'm not 100% sure. So we could leave this open for future examination, or just close it, if we're worried about potential side effects.

Related:
- #134