### PR TITLE
Annotation prop declaration refactor & `oio` refactor

### DIFF
--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -139,8 +139,9 @@ def omim2obo(use_cache: bool = False):
     # Populate graph
     # - Non-OMIM triples
     graph.add((URIRef('http://purl.obolibrary.org/obo/mondo/omim.owl'), RDF.type, OWL.Ontology))
-    graph.add((URIRef('http://www.geneontology.org/formats/oboInOwl#hasSynonymType'), RDF.type, OWL.AnnotationProperty))
-    graph.add((URIRef('http://purl.obolibrary.org/obo/mondo#omim_included'), RDF.type, OWL.AnnotationProperty))
+    graph.add((URIRef(OBOINOWL.hasSynonymType), RDF.type, OWL.AnnotationProperty))
+    graph.add((URIRef(MONDONS.omim_included), RDF.type, OWL.AnnotationProperty))
+    graph.add((URIRef(MONDONS.ABBREVIATION), RDF.type, OWL.AnnotationProperty))
     graph.add((BIOLINK['has_evidence'], RDF.type, OWL.AnnotationProperty))
     graph.add((TAX_URI, RDF.type, OWL.Class))
     graph.add((TAX_URI, RDFS.label, Literal(TAX_LABEL)))
@@ -160,7 +161,7 @@ def omim2obo(use_cache: bool = False):
                     graph.add((omim_uri, IAO['0100001'], OMIM[label_ids[0]]))
                 elif len(label_ids) > 1:
                     for replaced_mim_num in label_ids:
-                        graph.add((omim_uri, oboInOwl.consider, OMIM[replaced_mim_num]))
+                        graph.add((omim_uri, OBOINOWL.consider, OMIM[replaced_mim_num]))
                 continue
 
         # - Non-deprecated
@@ -209,16 +210,16 @@ def omim2obo(use_cache: bool = False):
         abbrev: Union[str, None] = None if not pref_symbols else pref_symbols[0]
 
         # Add synonyms
-        graph.add((omim_uri, oboInOwl.hasExactSynonym, Literal(label_cleaner.clean(pref_title, abbrev))))
+        graph.add((omim_uri, OBOINOWL.hasExactSynonym, Literal(label_cleaner.clean(pref_title, abbrev))))
         for alt_label in other_labels:
-            graph.add((omim_uri, oboInOwl.hasExactSynonym, Literal(label_cleaner.clean(alt_label, abbrev))))
+            graph.add((omim_uri, OBOINOWL.hasExactSynonym, Literal(label_cleaner.clean(alt_label, abbrev))))
         for abbreviation in pref_symbols:
-            graph.add((omim_uri, oboInOwl.hasExactSynonym, Literal(abbreviation)))
+            graph.add((omim_uri, OBOINOWL.hasExactSynonym, Literal(abbreviation)))
             # Reify on abbreviations. See: https://github.com/monarch-initiative/omim/issues/2
             axiom = BNode()
             graph.add((axiom, RDF.type, OWL.Axiom))
             graph.add((axiom, OWL.annotatedSource, omim_uri))
-            graph.add((axiom, OWL.annotatedProperty, oboInOwl.hasExactSynonym))
+            graph.add((axiom, OWL.annotatedProperty, OBOINOWL.hasExactSynonym))
             graph.add((axiom, OWL.annotatedTarget, Literal(abbreviation)))
             graph.add((axiom, OBOINOWL.hasSynonymType, MONDONS.abbreviation))
 

--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -139,7 +139,7 @@ def omim2obo(use_cache: bool = False):
     # Populate graph
     # - Non-OMIM triples
     graph.add((URIRef('http://purl.obolibrary.org/obo/mondo/omim.owl'), RDF.type, OWL.Ontology))
-    graph.add((URIRef(OBOINOWL.hasSynonymType), RDF.type, OWL.AnnotationProperty))
+    graph.add((URIRef(oboInOwl.hasSynonymType), RDF.type, OWL.AnnotationProperty))
     graph.add((URIRef(MONDONS.omim_included), RDF.type, OWL.AnnotationProperty))
     graph.add((URIRef(MONDONS.ABBREVIATION), RDF.type, OWL.AnnotationProperty))
     graph.add((BIOLINK['has_evidence'], RDF.type, OWL.AnnotationProperty))
@@ -161,7 +161,7 @@ def omim2obo(use_cache: bool = False):
                     graph.add((omim_uri, IAO['0100001'], OMIM[label_ids[0]]))
                 elif len(label_ids) > 1:
                     for replaced_mim_num in label_ids:
-                        graph.add((omim_uri, OBOINOWL.consider, OMIM[replaced_mim_num]))
+                        graph.add((omim_uri, oboInOwl.consider, OMIM[replaced_mim_num]))
                 continue
 
         # - Non-deprecated
@@ -210,18 +210,18 @@ def omim2obo(use_cache: bool = False):
         abbrev: Union[str, None] = None if not pref_symbols else pref_symbols[0]
 
         # Add synonyms
-        graph.add((omim_uri, OBOINOWL.hasExactSynonym, Literal(label_cleaner.clean(pref_title, abbrev))))
+        graph.add((omim_uri, oboInOwl.hasExactSynonym, Literal(label_cleaner.clean(pref_title, abbrev))))
         for alt_label in other_labels:
-            graph.add((omim_uri, OBOINOWL.hasExactSynonym, Literal(label_cleaner.clean(alt_label, abbrev))))
+            graph.add((omim_uri, oboInOwl.hasExactSynonym, Literal(label_cleaner.clean(alt_label, abbrev))))
         for abbreviation in pref_symbols:
-            graph.add((omim_uri, OBOINOWL.hasExactSynonym, Literal(abbreviation)))
+            graph.add((omim_uri, oboInOwl.hasExactSynonym, Literal(abbreviation)))
             # Reify on abbreviations. See: https://github.com/monarch-initiative/omim/issues/2
             axiom = BNode()
             graph.add((axiom, RDF.type, OWL.Axiom))
             graph.add((axiom, OWL.annotatedSource, omim_uri))
-            graph.add((axiom, OWL.annotatedProperty, OBOINOWL.hasExactSynonym))
+            graph.add((axiom, OWL.annotatedProperty, oboInOwl.hasExactSynonym))
             graph.add((axiom, OWL.annotatedTarget, Literal(abbreviation)))
-            graph.add((axiom, OBOINOWL.hasSynonymType, MONDONS.abbreviation))
+            graph.add((axiom, oboInOwl.hasSynonymType, MONDONS.abbreviation))
 
         # Add 'included' entry properties
         included_detected_comment = "This term has one or more labels that end with ', INCLUDED'."

--- a/omim2obo/namespaces.py
+++ b/omim2obo/namespaces.py
@@ -53,7 +53,7 @@ OBA = Namespace('http://purl.obolibrary.org/obo/OBA_')                        # 
 OBAN = Namespace('http://purl.org/oban/')                                     # Open Biomedical Annotation Model
 OBI = Namespace('http://purl.obolibrary.org/obo/OBI_')                        # Ontology of Biomedical Investigations
 OBO = Namespace('http://purl.obolibrary.org/obo/')                            # Biological Ontology namespace (this is not itself an ontology)
-OBOINOWL = Namespace('http://www.geneontology.org/formats/oboInOwl#')         # obo-specific annotation properties, like synonym types
+OBOINOWL = Namespace('http://www.geneontology.org/formats/oboInOwl#')
 # 'OMIA' was http://omia.angis.org.au/ IS https://omia.org/         # (see about helping to update original data)
 OMIA = Namespace('https://omia.org/OMIA')                                     # Online Mendelian Inheritance in Animals (disease/species)
 # LIDIA seems retired. so these are not resovable                   # Also: http://www.vetsci.usyd.edu.au/lida/
@@ -246,7 +246,6 @@ WD_ENTITY = Namespace('https://www.wikidata.org/wiki/')               # Wikidata
 PMID = Namespace('http://www.ncbi.nlm.nih.gov/pubmed/')
 ORPHANET = Namespace('http://www.orpha.net/ORDO/Orphanet_')
 UMLS = Namespace('http://linkedlifedata.com/resource/umls/id/')
-oboInOwl = Namespace('http://www.geneontology.org/formats/oboInOwl#')
 
 MONDONS = Namespace('http://purl.obolibrary.org/obo/mondo#')
 # # Monarch-specific
@@ -321,7 +320,6 @@ MONDONS = Namespace('http://purl.obolibrary.org/obo/mondo#')
 # 'OBAN': 'http://purl.org/oban/'                                     # Open Biomedical Annotation Model
 # 'OBI': 'http://purl.obolibrary.org/obo/OBI_'                        # Ontology of Biomedical Investigations
 # 'OBO': 'http://purl.obolibrary.org/obo/'                            # Biological Ontology namespace (this is not itself an ontology)
-# 'oboInOwl': 'http://www.geneontology.org/formats/oboInOwl#'         # obo-specific annotation properties, like synonym types
 # # 'OMIA' was http://omia.angis.org.au/ IS https://omia.org/         # (see about helping to update original data)
 # 'OMIA': 'https://omia.org/OMIA'                                     # Online Mendelian Inheritance in Animals (disease/species)
 # # LIDIA seems retired. so these are not resovable                   # Also: http://www.vetsci.usyd.edu.au/lida/

--- a/omim2obo/namespaces.py
+++ b/omim2obo/namespaces.py
@@ -53,7 +53,7 @@ OBA = Namespace('http://purl.obolibrary.org/obo/OBA_')                        # 
 OBAN = Namespace('http://purl.org/oban/')                                     # Open Biomedical Annotation Model
 OBI = Namespace('http://purl.obolibrary.org/obo/OBI_')                        # Ontology of Biomedical Investigations
 OBO = Namespace('http://purl.obolibrary.org/obo/')                            # Biological Ontology namespace (this is not itself an ontology)
-OBOINOWL = Namespace('http://www.geneontology.org/formats/oboInOwl#')
+oboInOwl = Namespace('http://www.geneontology.org/formats/oboInOwl#')         # obo-specific annotation properties, like synonym types
 # 'OMIA' was http://omia.angis.org.au/ IS https://omia.org/         # (see about helping to update original data)
 OMIA = Namespace('https://omia.org/OMIA')                                     # Online Mendelian Inheritance in Animals (disease/species)
 # LIDIA seems retired. so these are not resovable                   # Also: http://www.vetsci.usyd.edu.au/lida/

--- a/omim2obo/parsers/omim_entry_parser.py
+++ b/omim2obo/parsers/omim_entry_parser.py
@@ -62,9 +62,9 @@ def transform_entry(entry) -> Graph:
     else:  # ^ or NULL (no prefix character)
         graph.add((omim_uri, RDFS.label, Literal(cleanup_label(label))))
 
-    graph.add((omim_uri, OBOINOWL.hasExactSynonym, Literal(label)))
+    graph.add((omim_uri, oboInOwl.hasExactSynonym, Literal(label)))
     for label in other_labels:
-        graph.add((omim_uri, OBOINOWL.hasRelatedSynonym, Literal(label)))
+        graph.add((omim_uri, oboInOwl.hasRelatedSynonym, Literal(label)))
 
     if 'geneMapExists' in entry and entry['geneMapExists']:
         genemap = entry['geneMap']

--- a/omim2obo/parsers/omim_entry_parser.py
+++ b/omim2obo/parsers/omim_entry_parser.py
@@ -62,9 +62,9 @@ def transform_entry(entry) -> Graph:
     else:  # ^ or NULL (no prefix character)
         graph.add((omim_uri, RDFS.label, Literal(cleanup_label(label))))
 
-    graph.add((omim_uri, oboInOwl.hasExactSynonym, Literal(label)))
+    graph.add((omim_uri, OBOINOWL.hasExactSynonym, Literal(label)))
     for label in other_labels:
-        graph.add((omim_uri, oboInOwl.hasRelatedSynonym, Literal(label)))
+        graph.add((omim_uri, OBOINOWL.hasRelatedSynonym, Literal(label)))
 
     if 'geneMapExists' in entry and entry['geneMapExists']:
         genemap = entry['geneMap']


### PR DESCRIPTION
Annotation prop declaration refactor & oio refactor
    - Update: Annotation prop declaration UriRefs to use codebase standard (namespaces) instead of plain string URIs.
    - Delete: Duplicate oboInOwl namespace declaration
    - Update: All previous oboInOwl namespace usages to use the all-caps OBOINOWL, which is the standard for the codebase.