### PR TITLE
Disease-Gene: Self-referential cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,15 +105,31 @@ always in sync, and that one or the other may be slightly more up-to or out-of d
 
 ### `review.tsv`
 Columns:
-- `classCode`: integer: ID of review case class
-- `classShortName`: string (camelCase): describing the review case class
+- `classCode`: integer
+- `classLabel`: string
 - `value`: any: Some form of data to review
 - `comment`: string (optional)
 
-#### 1. `causalD2gButMarkedDigenic`
-This review case involves what would be otherwise considered a valid disease-gene relationship, but for the fact that 
-it quite unusually includes 'digenic' in the label, even though it only had 1 association. OMIM doesn't have a 
+#### 1. D2G Disease-defining but marked digenic
+This review case involves what would be otherwise considered a valid disease-gene (D2G) relationship, but for the fact 
+that it quite unusually includes 'digenic' in the label, even though it only had 1 association. OMIM doesn't have a 
 guaranatee on the data quality of its disease-gene associations marked 'digenic', so for any of these entries, it could 
 be the case that either (a) it is not 'digenic'; OMIM should remove that from the label, and Mondo can make an explicit 
 exception to add the relationship, or could otherwise wait until OMIM fixes the issue and it will automatically be 
 added, or (b) it is in fact 'digenic', and OMIM should add the missing 2nd gene association.
+
+#### 2. D2G: Disease-defining; self-referential
+The unique characteristics of cases of this class are as follows: 
+- Each case has 2 rows in `morbidmap.txt` and are related.
+- Row 1: One row is a typical, valid, disease-defining entry. For the given phenotype MIM in that row, there are no 
+- other rows in `morbidmap.txt` where it appears as a phenotype having an association with another gene.
+  - In all such cases seen thus far as of 2024/11/18, all of these are cancer cases, and the label ends with "somatic".
+  - This entry appears in the Phenotype-Gene Relationships table on the MIM's omim.org/entry page.
+- Row 2: There is a second row where the phenotype in the first row appears as a gene.
+  - For this row, there is no MIM in the phenotype field.
+  - This row does not appear in the Gene-Phenotype Relationships table on the MIM's omim.org/entry page.
+  - This row is self-referential. The label in the Phenotype field is one of the titles of the MIM in the Gene field.
+
+There is a spreadsheet which collates all known cases as of 2024/11/18: [google sheet](
+https://docs.google.com/spreadsheets/d/1hKSp2dyKye6y_20NK2HwLsaKNzWfGCMJMP52lKrkHtU/). The MIMs of the known cases are: 
+159595, 182280, 607107, and 615830.

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ In order to add these associations to an OWL ontology, we must use an appropriat
 `morbidmap.txt` mapping keys and [their definitions](https://omim.org/help/faq#1_6), alongside the RO predicates we've 
 chosen to represent them.
 
-Note that the directionality of these associations / predicates is in the Disease->Gene direction:
-(Disease MIM) --(Mapping key / RO predicate)--> (Gene MIM)
+Note that the directionality of these associations / predicates is in the Gene->Disease direction:
+(Gene MIM) --(Mapping key / RO predicate)--> (Disease MIM)
 
 1: The disorder is placed on the map based on its association with a gene, but the underlying defect is not known.  
 Not ontologized. These types are ignored due to the uncertainty of the nature of the association.
@@ -192,7 +192,7 @@ Relates a gene to condition, such that a mutation in this gene is sufficient to 
 passed on to offspring[modified from orphanet].
 
 Note: For these "mapping key (3)" cases, there also exists an inverse predicate which we ontologize in the 
-inverse direction: (Gene MIM) --(Mapping key 3 / RO:0004003)--> (Disease MIM):
+inverse direction: (Disease MIM) --(Mapping key 3 / RO:0004003)--> (Gene MIM):
 [RO:0004003 (has material basis in germline mutation in)](https://www.ebi.ac.uk/ols4/ontologies/ro/properties?iri=http://purl.obolibrary.org/obo/RO_0004003) 
 
 4: A contiguous gene deletion or duplication syndrome, multiple genes are deleted or duplicated causing the phenotype.  
@@ -210,15 +210,18 @@ In cases where there is >1 association, the following RO predicate is used inste
 A relationship between an entity (e.g. a genotype, genetic variation, chemical, or environmental exposure) and a 
 condition (a phenotype or disease), where the entity has some causal or contributing role that influences the condition.
 
-#### Necessary conditions for disease-defining associations (RO:0004013)
-Of the above 3 Disease->Gene association predicates (those with mapping keys (2), (3), and (4)), the one which we 
-consider "disease defining" is (3) (RO:0004013). For this association, we also have other conditions that we check. If 
-not all of these conditions are met, then the association does not get ontologized; no association gets added to 
-`omim.ttl`. The extra conditions are that (i) the Phenotype not be marked as a non-disease (represented by the label 
+#### Necessary conditions for disease-defining associations
+Of the above 3 Gene->Disease association predicates (those with mapping keys (2), (3), and (4)), the one which we 
+consider "disease defining" is (3) (RO:0004013). For these cases, as mentioned above, we also declare an association in 
+the Disease->Gene direction, RO:0004003. However, we only declare these associations if several other conditions are 
+also met. These other conditions are: (i) the Phenotype not be marked as a non-disease (represented by the label 
 being wrapped in `[]`), (ii) that is not a mutation that contribute to susceptibility to multifactorial disorders 
 (e.g., diabetes, asthma) or to susceptibility to infection (e.g., malaria) (represented by the label being wrapped in 
 `{}`), and (iii) not be marked provisional (represented by the label beginning with `?`). These 3 special markers are 
-further explained in the [OMIM FAQ](https://omim.org/help/faq#1_6). So, all of the conditions together are:
+further explained in the [OMIM FAQ](https://omim.org/help/faq#1_6). Additionally, as mentioned above, we only declare 
+the association in `omim.ttl` if there is 1 and only 1 association shown in `morbidmap.txt
+
+So, all of the conditions together are:
 1. Mapping key is (3)
 2. Only 1 association
 3. Phenotype not marked as non-disease (`[]`)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ added, or (b) it is in fact 'digenic', and OMIM should add the missing 2nd gene 
 
 #### 2. D2G: Disease-defining; self-referential
 The unique characteristics of cases of this class are as follows: 
-- Each case has 2 rows in `morbidmap.txt` and are related.
+- Each case has 2 rows in `morbidmap.txt` and are part of a pattern. 
 - Row 1: One row is a typical, valid, disease-defining entry. For the given phenotype MIM in that row, there are no 
 - other rows in `morbidmap.txt` where it appears as a phenotype having an association with another gene.
   - In all such cases seen thus far as of 2024/11/18, all of these are cancer cases, and the label ends with "somatic".
@@ -130,9 +130,16 @@ The unique characteristics of cases of this class are as follows:
   - This row does not appear in the Gene-Phenotype Relationships table on the MIM's omim.org/entry page.
   - This row is self-referential. The label in the Phenotype field is one of the titles of the MIM in the Gene field.
 
+**Example case**:
+|Phenotype|Gene/Locus And Other Related Symbols|MIM Number|Cyto Location|
+|-|-|-|-|
+|Small cell cancer of the lung, somatic, 182280 (3)|RB1|614041|13q14.2|
+|Small-cell cancer of lung (2)|SCLC1|182280|3p23-p21|
+
+
+**All known cases**:
 There is a spreadsheet which collates all known cases as of 2024/11/18: [google sheet](
-https://docs.google.com/spreadsheets/d/1hKSp2dyKye6y_20NK2HwLsaKNzWfGCMJMP52lKrkHtU/). The MIMs of the known cases are: 
-159595, 182280, 607107, and 615830.
+https://docs.google.com/spreadsheets/d/1hKSp2dyKye6y_20NK2HwLsaKNzWfGCMJMP52lKrkHtU/). The MIMs of the known cases are: `159595`, `182280`, `607107`, and `615830`.
 
 ## Under the hood: Design decisions, etc.
 ### Gene-Disease pipeline

--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -141,7 +141,7 @@ CONFIG = {
 
 
 # Main
-def omim2obo(use_cache: bool = False):
+def omim2obo(use_cache: bool = True):
     """Run program"""
     graph = OmimGraph.get_graph()
     download_files_tf: bool = not use_cache
@@ -303,6 +303,8 @@ def omim2obo(use_cache: bool = False):
             phenotype_genes[p_mim].append({
                 'gene_id': gene_mim, 'phenotype_label': p_lab, 'mapping_key': p_map_key, 'mapping_label': p_map_lab})
 
+    self_ref_case = 0
+    self_ref_rows: List[Dict] = []
     # - Add relations (subclass restrictions)
     for p_mim, assocs in phenotype_genes.items():
         for assoc in assocs:
@@ -345,6 +347,31 @@ def omim2obo(use_cache: bool = False):
             if p_mim_type == 'GENE':  # *
                 print(mim_type_err, file=sys.stderr)  # OMIM recognized as data quality issue. Fixed 2024/11. Failsafe.
 
+            def get_self_ref_assocs(_mim: str) -> List[Dict]:
+                """Find any cases where it appears that there is a self-referential gene-disease association"""
+                if p_mim not in gene_phenotypes:
+                    return []
+                _assocs = gene_phenotypes[_mim]['phenotype_associations']
+                _self_ref_assocs = []
+                for _assoc in _assocs:
+                    if not _assoc['phenotype_mim_number']:
+                        _self_ref_assocs.append(_assoc)
+                return _self_ref_assocs
+            self_ref_assocs: List[Dict] = get_self_ref_assocs(p_mim)
+            if len(self_ref_assocs) > 1:
+                raise RuntimeError('Unexpected self-referential disease-gene assoc w/ > 1 self ref')  # Failsafe. n=0
+            if self_ref_assocs:
+                self_ref_case += 1
+                self_ref_rows.append({
+                    'case': self_ref_case, 'disease': p_mim, 'disease_label': p_lab, 'map_key': p_map_key,
+                    'gene': gene_mim
+                })
+                for ass in self_ref_assocs:
+                    self_ref_rows.append({
+                        'case': self_ref_case, 'disease': '', 'disease_label': ass['phenotype_label'], 'map_key':
+                        ass['phenotype_mapping_info_key'], 'gene': p_mim
+                    })
+
             # Disease --(RO:0004003 'has material basis in germline mutation in')--> Gene
             # https://www.ebi.ac.uk/ols4/ontologies/ro/properties?iri=http://purl.obolibrary.org/obo/RO_0004003
             add_subclassof_restriction_with_evidence(
@@ -353,6 +380,9 @@ def omim2obo(use_cache: bool = False):
             # https://www.ebi.ac.uk/ols4/ontologies/ro/properties?iri=http://purl.obolibrary.org/obo/RO_0004013
             add_subclassof_restriction_with_evidence(
                 graph, RO['0004013'], OMIM[p_mim], OMIM[gene_mim], evidence)
+
+    self_ref_df = pd.DataFrame(self_ref_rows)
+    self_ref_df.to_csv('~/Desktop/self-referential-g2d.tsv', index=False, sep='\t')
 
     # PUBMED, UMLS
     # How do we get these w/out relying on this ttl file? Possible? Where is it from? - joeflack4 2021/11/11

--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -320,13 +320,13 @@ def omim2obo(use_cache: bool = False):
             if not p_mim or p_map_key == '1':
                 continue
 
-            # Add restrictions: Gene->Disease non-causal relationships
+            # Add restrictions: Gene->Disease non-causal (disease-defining) relationships
             # - RO:0003302 docs: see MORBIDMAP_PHENOTYPE_MAPPING_KEY_PREDICATES
-            if p_map_key != '3':  # 3 = 'causal'. Handled separately below.
+            if p_map_key != '3':  # 3 = 'causal' (disease-defining). Handled separately below.
                 g2d_pred = MORBIDMAP_PHENOTYPE_MAPPING_KEY_PREDICATES[p_map_key] if len(assocs) == 1 else RO['0003302']
                 add_subclassof_restriction_with_evidence(graph, g2d_pred, OMIM[p_mim], OMIM[gene_mim], evidence)
 
-            # Skip non-causal cases
+            # Skip non-causal (disease-defining) cases
             if len(assocs) > 1 or p_map_key != '3' or not p2g_is_definitive(p_lab):
                 continue
 
@@ -339,7 +339,7 @@ def omim2obo(use_cache: bool = False):
                     "classShortName": "D2G: Disease-defining but marked digenic",
                     "value": f"(Phenotype: {p_mim} {p_lab}) (Gene: {gene_mim})",
                 })
-            # -Self-referential cases
+            # - Self-referential cases
             self_ref_assocs: List[Dict] = get_self_ref_assocs(p_mim, gene_phenotypes)
             if self_ref_assocs:
                 self_ref_case += 1
@@ -367,7 +367,7 @@ def omim2obo(use_cache: bool = False):
             if p_mim_type == 'GENE':  # *
                 print(mim_type_err, file=sys.stderr)  # OMIM recognized as data quality issue. Fixed 2024/11. Failsafe.
 
-            # Add restrictions: causal germline mutation
+            # Add restrictions: Disease-defining ('causal germline mutation')
             # - Disease --(RO:0004003 'has material basis in germline mutation in')--> Gene
             #   https://www.ebi.ac.uk/ols4/ontologies/ro/properties?iri=http://purl.obolibrary.org/obo/RO_0004003
             add_subclassof_restriction_with_evidence(

--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -54,7 +54,7 @@ from rdflib.term import Identifier
 from omim2obo.config import REVIEW_CASES_PATH, ROOT_DIR, GLOBAL_TERMS, ReviewCase
 from omim2obo.namespaces import *
 from omim2obo.parsers.omim_entry_parser import get_alt_labels, get_pubs, get_mapped_ids, LabelCleaner, \
-    has_self_ref_assocs
+    get_self_ref_assocs
 from omim2obo.parsers.omim_txt_parser import *  # todo: change to specific imports
 
 
@@ -304,6 +304,7 @@ def omim2obo(use_cache: bool = False):
             phenotype_genes[p_mim].append({
                 'gene_id': gene_mim, 'phenotype_label': p_lab, 'mapping_key': p_map_key, 'mapping_label': p_map_lab})
 
+    self_ref_case = 0
     # - Add relations (subclass restrictions)
     for p_mim, assocs in phenotype_genes.items():
         for assoc in assocs:
@@ -311,7 +312,7 @@ def omim2obo(use_cache: bool = False):
                 assoc['mapping_key'], assoc['mapping_label']
             evidence = f'Evidence: ({p_map_key}) {p_map_lab}'
 
-            # General skippable cases
+            # Skip: No phenotype or unknown defect
             # - not p_mim: Skip because not an association to another MIM (Provenance:
             #  https://github.com/monarch-initiative/omim/issues/78)
             # - p_map_key == '1': Skip because association w/ unknown defect (Provenance:
@@ -319,25 +320,45 @@ def omim2obo(use_cache: bool = False):
             if not p_mim or p_map_key == '1':
                 continue
 
-            # Gene->Disease non-causal relationships
+            # Add restrictions: Gene->Disease non-causal relationships
             # - RO:0003302 docs: see MORBIDMAP_PHENOTYPE_MAPPING_KEY_PREDICATES
             if p_map_key != '3':  # 3 = 'causal'. Handled separately below.
                 g2d_pred = MORBIDMAP_PHENOTYPE_MAPPING_KEY_PREDICATES[p_map_key] if len(assocs) == 1 else RO['0003302']
                 add_subclassof_restriction_with_evidence(graph, g2d_pred, OMIM[p_mim], OMIM[gene_mim], evidence)
 
-            # Disease->Gene & Gene->Disease: Causal relationships
-            # - Skip non-causal cases
-            #  - 3: The molecular basis for the disorder is known; a mutation has been found in the gene.
+            # Skip non-causal cases
             if len(assocs) > 1 or p_map_key != '3' or not p2g_is_definitive(p_lab):
                 continue
-            #  - Digenic: Should technically be none marked 'digenic' if only 1 association, but there are.
+
+            # Log review cases
+            # - Digenic: Should technically be none marked 'digenic' if only 1 association, but there are.
             if 'digenic' in p_lab.lower():
                 # noinspection PyTypeChecker typecheck_fail_old_Python
                 REVIEW_CASES.append({
                     "classCode": 1,
-                    "classShortName": "causalD2gButMarkedDigenic",
-                    "value": f"OMIM:{p_mim}: {p_lab} (Gene: OMIM:{gene_mim})",
+                    "classShortName": "D2G: Disease-defining but marked digenic",
+                    "value": f"(Phenotype: {p_mim} {p_lab}) (Gene: {gene_mim})",
                 })
+            # -Self-referential cases
+            self_ref_assocs: List[Dict] = get_self_ref_assocs(p_mim, gene_phenotypes)
+            if self_ref_assocs:
+                self_ref_case += 1
+                REVIEW_CASES.append({
+                    "classCode": 2,
+                    "classShortName": "D2G: Disease-defining; self-referential",
+                    "value":
+                        f"{self_ref_case}: (Phenotype: {p_mim} {p_lab}), (Map key: {p_map_key}), (Gene: {gene_mim})",
+                })
+            for self_ref_assoc in self_ref_assocs:
+                # noinspection PyTypeChecker typecheck_fail_old_Python
+                REVIEW_CASES.append({
+                    "classCode": 2,
+                    "classShortName": "D2G: Disease-defining; self-referential",
+                    "value": f"{self_ref_case}: (Phenotype: {self_ref_assoc['phenotype_label']}), (Map key: "
+                             f"{self_ref_assoc['phenotype_mapping_info_key']}), (Gene: OMIM:{p_mim})",
+                })
+            # - Unexpected non-phenotype MIM types
+            # todo: these need to be in review.tsv as well
             p_mim_type: str = omim_types[p_mim]  # Allowable: PHENOTYPE, HERITABLE_PHENOTYPIC_MARKER (#, %)
             mim_type_err = f"Warning: Unexpected MIM type {p_mim_type} for Phenotype {p_mim} when parsing phenotype-" \
                 f"disease relationships. Skipping."
@@ -346,21 +367,13 @@ def omim2obo(use_cache: bool = False):
             if p_mim_type == 'GENE':  # *
                 print(mim_type_err, file=sys.stderr)  # OMIM recognized as data quality issue. Fixed 2024/11. Failsafe.
 
-            # Self-referential special cases.
-            # Known cases: https://docs.google.com/spreadsheets/d/1hKSp2dyKye6y_20NK2HwLsaKNzWfGCMJMP52lKrkHtU/
-            if has_self_ref_assocs(p_mim, gene_phenotypes):
-                if p_mim not in ('159595', '182280', '607107', '615830'):  # previously known cases
-                    # todo: Add to review.tsv?
-                    print(f'Unexpected new self-referential case: OMIM:{p_mim}: {p_lab} (Gene: OMIM:{gene_mim})',
-                          file=sys.stderr)
-                continue
-
-            # Disease --(RO:0004003 'has material basis in germline mutation in')--> Gene
-            # https://www.ebi.ac.uk/ols4/ontologies/ro/properties?iri=http://purl.obolibrary.org/obo/RO_0004003
+            # Add restrictions: causal germline mutation
+            # - Disease --(RO:0004003 'has material basis in germline mutation in')--> Gene
+            #   https://www.ebi.ac.uk/ols4/ontologies/ro/properties?iri=http://purl.obolibrary.org/obo/RO_0004003
             add_subclassof_restriction_with_evidence(
                 graph, RO['0004003'], OMIM[gene_mim], OMIM[p_mim], evidence)
-            # Gene --(RO:0004013 'is causal germline mutation in')--> Disease
-            # https://www.ebi.ac.uk/ols4/ontologies/ro/properties?iri=http://purl.obolibrary.org/obo/RO_0004013
+            # - Gene --(RO:0004013 'is causal germline mutation in')--> Disease
+            #   https://www.ebi.ac.uk/ols4/ontologies/ro/properties?iri=http://purl.obolibrary.org/obo/RO_0004013
             add_subclassof_restriction_with_evidence(
                 graph, RO['0004013'], OMIM[p_mim], OMIM[gene_mim], evidence)
 
@@ -389,7 +402,8 @@ def omim2obo(use_cache: bool = False):
         for orphanet_id in orphanet_ids:
             graph.add((OMIM[mim_number], SKOS.exactMatch, ORPHANET[orphanet_id]))
 
-    review_df = pd.DataFrame(REVIEW_CASES)  # todo: ensure comment field exists even when no row uses
+    # todo: ensure comment field exists even when no row uses
+    review_df = pd.DataFrame(REVIEW_CASES).sort_values(by=['classCode'])
     review_df.to_csv(REVIEW_CASES_PATH, index=False, sep='\t')
     with open(OUTPATH, 'w') as f:
         f.write(graph.serialize(format='turtle'))

--- a/omim2obo/parsers/omim_entry_parser.py
+++ b/omim2obo/parsers/omim_entry_parser.py
@@ -383,3 +383,26 @@ class LabelCleaner():
         """Overrides cleanup_label by adding word_replacements"""
         return cleanup_label(
             label, *args, **kwargs, word_replacements=self.word_replacements)
+
+
+def get_self_ref_assocs(phenotype_mim: str, gene_phenotypes: Dict[str, Dict]) -> List[Dict]:
+    """Find any cases where it appears that there is a self-referential gene-disease association"""
+    if phenotype_mim not in gene_phenotypes:
+        return []
+    _assocs = gene_phenotypes[phenotype_mim]['phenotype_associations']
+    _self_ref_assocs = []
+    for _assoc in _assocs:
+        if not _assoc['phenotype_mim_number']:
+            _self_ref_assocs.append(_assoc)
+    return _self_ref_assocs
+
+
+def has_self_ref_assocs(phenotype_mim: str, gene_phenotypes: Dict[str, Dict]) -> bool:
+    """Check whether has self referential associations
+
+    Several anomalies with these:
+     Self-referential “phenotype in the gene position + Phenotype field without a MIM” + "morbidmap.txt entry not in
+      Phenotype-Gene Relationships table" on website
+     Also all marked as 'somatic'.
+    """
+    return len(get_self_ref_assocs(phenotype_mim, gene_phenotypes)) > 0

--- a/omim2obo/parsers/omim_entry_parser.py
+++ b/omim2obo/parsers/omim_entry_parser.py
@@ -395,14 +395,3 @@ def get_self_ref_assocs(phenotype_mim: str, gene_phenotypes: Dict[str, Dict]) ->
         if not _assoc['phenotype_mim_number']:
             _self_ref_assocs.append(_assoc)
     return _self_ref_assocs
-
-
-def has_self_ref_assocs(phenotype_mim: str, gene_phenotypes: Dict[str, Dict]) -> bool:
-    """Check whether has self referential associations
-
-    Several anomalies with these:
-     Self-referential “phenotype in the gene position + Phenotype field without a MIM” + "morbidmap.txt entry not in
-      Phenotype-Gene Relationships table" on website
-     Also all marked as 'somatic'.
-    """
-    return len(get_self_ref_assocs(phenotype_mim, gene_phenotypes)) > 0


### PR DESCRIPTION
Disease-Gene: Self-referential somatic cancers
Self-referential “phenotype in the gene position + Phenotype field without a MIM” + "morbidmap.txt entry not in Phenotype-Gene Relationships table" case - add to `review.tsv`

All current cases: [Google Sheet](https://docs.google.com/spreadsheets/d/1hKSp2dyKye6y_20NK2HwLsaKNzWfGCMJMP52lKrkHtU/edit?gid=1826025296#gid=1826025296)