### PR TITLE
`MONDO:omim_included` rename

### DIFF
--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -164,7 +164,7 @@ def omim2obo(use_cache: bool = False):
     # - Non-OMIM triples
     graph.add((URIRef('http://purl.obolibrary.org/obo/mondo/omim.owl'), RDF.type, OWL.Ontology))
     graph.add((URIRef(oboInOwl.hasSynonymType), RDF.type, OWL.AnnotationProperty))
-    graph.add((URIRef(MONDONS.omim_included), RDF.type, OWL.AnnotationProperty))
+    graph.add((URIRef(MONDONS.includedEntryInOMIM), RDF.type, OWL.AnnotationProperty))
     graph.add((URIRef(OMO['0003000']), RDF.type, OWL.AnnotationProperty))
     graph.add((BIOLINK['has_evidence'], RDF.type, OWL.AnnotationProperty))
     graph.add((TAX_URI, RDF.type, OWL.Class))
@@ -252,7 +252,7 @@ def omim2obo(use_cache: bool = False):
         if label_endswith_included_alt or label_endswith_included_inc:
             graph.add((omim_uri, RDFS['comment'], Literal(included_detected_comment)))
         for included_label in cleaned_inc_labels:
-            graph.add((omim_uri, URIRef(MONDONS.omim_included), Literal(label_cleaner.clean(included_label, abbrev))))
+            graph.add((omim_uri, URIRef(MONDONS.includedEntryInOMIM), Literal(label_cleaner.clean(included_label, abbrev))))
 
     # Gene ID
     # Why is 'skos:exactMatch' appropriate for disease::gene relationships? - joeflack4 2022/06/06


### PR DESCRIPTION
## Changes
- Rename to be in line with what is in `MONDO:includedEntryInOMIM`

## Thoughts
There is a small discrepancy between `MONDO:includedEntryInOMIM` and new `MONDO:OMIM_formerly` in that the latter is "OMIM-namespaced" (OMIM comes first), and the former isn't. Personally I would like them to be both be in the "namespaced order", but It would be a bit much to bother changing it to `MONDO:OMIMincludedEntry` now.