### PR TITLE
`review.tsv` updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ There is a spreadsheet which collates all known cases as of 2024/11/18: [google 
 https://docs.google.com/spreadsheets/d/1hKSp2dyKye6y_20NK2HwLsaKNzWfGCMJMP52lKrkHtU/). The MIMs of the known cases are: `159595`, `182280`, `607107`, and `615830`.
 
 **Additional notes**:
-Note that unlike the other `review.tsv` cases, for this one, a single case spans multiple rows. The cases can be 
-identified easily because they are enumerated with a leading number in the `value` column, e.g. "1: " for the first case
-, and so on.
+Note that unlike the other cases, a single case of "D2G: self-referential" spans multiple rows in `review.tsv`. 
+The cases are enumerated in the TSV, with individual cases identifiable via a leading integer in the `value` column, 
+e.g. "1: " for the first case, "2: " for the second, and so on.
 
 Also, see note in section "3. D2G: somatic" about intersection between these two cases. 
 

--- a/README.md
+++ b/README.md
@@ -148,9 +148,7 @@ e.g. "1: " for the first case, "2: " for the second, and so on.
 Also, see note in section "3. D2G: somatic" about intersection between these two cases. 
 
 #### 3. D2G: somatic
-Happens when all conditions were met for this association to be considered disease-defining, but the word 'somatic' is 
-in the phenotype label. These are somatic mutation entries in OMIM, but typically they are germline mutations, and that 
-is what we ideally always expect to see, so these should be given a look.
+Happens when all conditions were met for this association to be considered disease-defining, but the mutation is a somatic cell mutation, rather than a germline mutation. This is indicated by the appearance of the word 'somatic' in the label of the phenotype MIM in the association. These cases should be reviewed because currently any association meeting the criteria to be considered disease-defining is also considered a germline mutation and the association is represented in `omim.owl` using the property 'is causal germline mutation in' (RO:0004013).
 
 Note that there is an intersection between this case and case 2, "D2G: self-referential". Sometimes the somatic cases 
 will also be self-referential, but not always. However, all cases of "D2G: self-referential" have historically included 

--- a/README.md
+++ b/README.md
@@ -136,15 +136,25 @@ The unique characteristics of cases of this class are as follows:
 |Small cell cancer of the lung, somatic, 182280 (3)|RB1|614041|13q14.2|
 |Small-cell cancer of lung (2)|SCLC1|182280|3p23-p21|
 
-
 **All known cases**:
 There is a spreadsheet which collates all known cases as of 2024/11/18: [google sheet](
 https://docs.google.com/spreadsheets/d/1hKSp2dyKye6y_20NK2HwLsaKNzWfGCMJMP52lKrkHtU/). The MIMs of the known cases are: `159595`, `182280`, `607107`, and `615830`.
+
+**Additional notes**:
+Note that unlike the other `review.tsv` cases, for this one, a single case spans multiple rows. The cases can be 
+identified easily because they are enumerated with a leading number in the `value` column, e.g. "1: " for the first case
+, and so on.
+
+Also, see note in section "3. D2G: somatic" about intersection between these two cases. 
 
 #### 3. D2G: somatic
 Happens when all conditions were met for this association to be considered disease-defining, but the word 'somatic' is 
 in the phenotype label. These are somatic mutation entries in OMIM, but typically they are germline mutations, and that 
 is what we ideally always expect to see, so these should be given a look.
+
+Note that there is an intersection between this case and case 2, "D2G: self-referential". Sometimes the somatic cases 
+will also be self-referential, but not always. However, all cases of "D2G: self-referential" have historically included 
+a row where the phenotype includes the word 'somatic'.
 
 #### 4. D2G: Phenotype is gene
 Happens when all conditions were met for this association to be considered disease-defining. However, the phenotype in 

--- a/README.md
+++ b/README.md
@@ -110,15 +110,15 @@ Columns:
 - `value`: any: Some form of data to review
 - `comment`: string (optional)
 
-#### 1. D2G Disease-defining but marked digenic
-This review case involves what would be otherwise considered a valid disease-gene (D2G) relationship, but for the fact 
-that it quite unusually includes 'digenic' in the label, even though it only had 1 association. OMIM doesn't have a 
-guaranatee on the data quality of its disease-gene associations marked 'digenic', so for any of these entries, it could 
-be the case that either (a) it is not 'digenic'; OMIM should remove that from the label, and Mondo can make an explicit 
-exception to add the relationship, or could otherwise wait until OMIM fixes the issue and it will automatically be 
-added, or (b) it is in fact 'digenic', and OMIM should add the missing 2nd gene association.
+#### 1. D2G: digenic
+This review case involves what would be otherwise considered a valid, disease-defining disease-gene (D2G) relationship, 
+but for the fact  that it quite unusually includes 'digenic' in the label, even though it only had 1 association. OMIM 
+doesn't have a guaranatee on the data quality of its disease-gene associations marked 'digenic', so for any of these 
+entries, it could  be the case that either (a) it is not 'digenic'; OMIM should remove that from the label, and Mondo 
+can make an explicit exception to add the relationship, or could otherwise wait until OMIM fixes the issue and it will 
+automatically be added, or (b) it is in fact 'digenic', and OMIM should add the missing 2nd gene association.
 
-#### 2. D2G: Disease-defining; self-referential
+#### 2. D2G: self-referential
 The unique characteristics of cases of this class are as follows: 
 - Each case has 2 rows in `morbidmap.txt` and are part of a pattern. 
 - Row 1: One row is a typical, valid, disease-defining entry. For the given phenotype MIM in that row, there are no 
@@ -140,6 +140,21 @@ The unique characteristics of cases of this class are as follows:
 **All known cases**:
 There is a spreadsheet which collates all known cases as of 2024/11/18: [google sheet](
 https://docs.google.com/spreadsheets/d/1hKSp2dyKye6y_20NK2HwLsaKNzWfGCMJMP52lKrkHtU/). The MIMs of the known cases are: `159595`, `182280`, `607107`, and `615830`.
+
+#### 3. D2G: somatic
+Happens when all conditions were met for this association to be considered disease-defining, but the word 'somatic' is 
+in the phenotype label. These are somatic mutation entries in OMIM, but typically they are germline mutations, and that 
+is what we ideally always expect to see, so these should be given a look.
+
+#### 4. D2G: Phenotype is gene
+Happens when all conditions were met for this association to be considered disease-defining. However, the phenotype in 
+the association unexpectedly has the type of "gene" rather than "phenotype". This is unexpected and considered a data 
+quality issue on the OMIM side. As of 2024/10, we flagged this to the OMIM team and they corrected all such cases.
+
+#### 5. D2G: Phenotype type error
+Happens when all conditions were met for this association to be considered disease-defining. However, the phenotype in 
+the association has an unexpected type of either 'OBSOLETE', 'SUSPECTED', or 'HAS_AFFECTED_FEATURE'. As of 2024/12, we 
+have not seen such cases appear, but we have set this review case up to watch for them should they occur.
 
 ## Under the hood: Design decisions, etc.
 ### Gene-Disease pipeline

--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -412,7 +412,7 @@ def omim2obo(use_cache: bool = False):
             self_ref_assocs: List[Dict] = get_self_ref_assocs(p_mim, gene_phenotypes)
             if self_ref_assocs:
                 self_ref_case += 1
-                _add_to_review_tsv(2,f"{self_ref_case}: {basic_review_info}")
+                _add_to_review_tsv(2, f"{self_ref_case}: {basic_review_info}")
             for self_ref_assoc in self_ref_assocs:
                 _add_to_review_tsv(2, f"{self_ref_case}: (Phenotype: {self_ref_assoc['phenotype_label']}), (Map key: "
                     f"{self_ref_assoc['phenotype_mapping_info_key']}), (Gene: {p_mim})",)
@@ -460,7 +460,7 @@ def omim2obo(use_cache: bool = False):
             graph.add((OMIM[mim_number], SKOS.exactMatch, ORPHANET[orphanet_id]))
 
     # todo: ensure comment field exists even when no row uses
-    review_df = pd.DataFrame(REVIEW_CASES).sort_values(by=['classCode'])
+    review_df = pd.DataFrame(REVIEW_CASES).sort_values(by=['classCode', 'value'])
     review_df.to_csv(REVIEW_CASES_PATH, index=False, sep='\t')
     with open(OUTPATH, 'w') as f:
         f.write(graph.serialize(format='turtle'))

--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -237,7 +237,7 @@ def omim2obo(use_cache: bool = False):
         is_gene = omim_type == OmimType.GENE or omim_type == OmimType.HAS_AFFECTED_FEATURE
         if omim_type == OmimType.HERITABLE_PHENOTYPIC_MARKER:  # '%' char
             graph.add((omim_uri, BIOLINK['category'], BIOLINK['Disease']))
-        elif is_gene:  # * or + chars
+        elif is_gene:  # Represented by: * or + chars
             graph.add((omim_uri, RDFS.subClassOf, SO['0000704']))  # gene
             graph.add((omim_uri, MONDO.exclusionReason, MONDO.nonDisease))
             graph.add((omim_uri, BIOLINK['category'], BIOLINK['Gene']))

--- a/omim2obo/parsers/omim_entry_parser.py
+++ b/omim2obo/parsers/omim_entry_parser.py
@@ -451,7 +451,7 @@ def log_review_cases(
     # - Unexpected non-phenotype MIM types
     p_mim_type: str = omim_types[p_mim]  # Allowable: PHENOTYPE, HERITABLE_PHENOTYPIC_MARKER (#, %)
     mim_type_err = f"(Phenotype MIM type {p_mim_type}), {basic_review_info}"
-    if p_mim_type == 'GENE':  # *
+    if p_mim_type == 'GENE':  # Represented by: *
         _add_to_review_tsv(4, mim_type_err)
-    elif p_mim_type in ('OBSOLETE', 'SUSPECTED', 'HAS_AFFECTED_FEATURE'):  # ^, NULL, +
+    elif p_mim_type in ('OBSOLETE', 'SUSPECTED', 'HAS_AFFECTED_FEATURE'):  # Represented by: ^, NULL, +
         _add_to_review_tsv(5, mim_type_err)


### PR DESCRIPTION
addresses #175
addresses #169

## Changes
- Add: New cases: '3. D2G: somatic', '4. D2G: Phenotype is gene', and '5. D2G: Phenotype type error'.
- Renamed the classLabel for the 2 existing review cases to be shorter / simpler.
- Refactored code for DRYness, adding _add_to_review_tsv() and REVIEW_CASE_NAME_MAP. Also streamlined the values / error messages for these to be more consistent and easier to read.
- Refactor: Moved review.tsv code into a separate function in order to make the disease2gene section more readable.
- Bug fix: Fixed a sorting issue for the 'self-referential' review case.
- Docs: Added clarifying text about how to easily identify individual cases when a case contains multiple rows.

## Additional info
- [`review.tsv` google sheet](https://docs.google.com/spreadsheets/d/1R4yKwiwkAWoWYObh415kyilRpRV4UnbAe1Oq4WBxkfI/edit?gid=974592092#gid=974592092)