### PR TITLE
Disease-Gene exclusions

### DIFF
--- a/data/exclusions-disease-gene.tsv
+++ b/data/exclusions-disease-gene.tsv
@@ -1,0 +1,8 @@
+omim_id	mondo_id	mondo_label	orcid	exclusion_reason_comment
+OMIM:603956	MONDO:0002974	cervical cancer'		evidence of various genes involved
+OMIM:619151	MONDO:0030894	AMED syndrome, digenic'		digenic
+OMIM:158901	MONDO:0008031			digenic
+OMIM:108770	MONDO:0007171	atrial standstill 1'		digenic
+OMIM:620040	MONDO:0031057	dyskeratosis congenita, digenic'		digenic
+OMIM:619478	MONDO:0030355	facioscapulohumeral muscular dystrophy 4, digenic'		digenic
+OMIM:300818	MONDO:0010438	paroxysmal nocturnal hemoglobinuria 1		disease caused by a somatic mutation, therefore a gene association stating this is due to a germline mutation should not be added

--- a/data/exclusions-disease-gene.tsv
+++ b/data/exclusions-disease-gene.tsv
@@ -1,8 +1,8 @@
 omim_id	mondo_id	mondo_label	orcid	exclusion_reason_comment
-OMIM:603956	MONDO:0002974	cervical cancer'		evidence of various genes involved
-OMIM:619151	MONDO:0030894	AMED syndrome, digenic'		digenic
-OMIM:158901	MONDO:0008031			digenic
-OMIM:108770	MONDO:0007171	atrial standstill 1'		digenic
-OMIM:620040	MONDO:0031057	dyskeratosis congenita, digenic'		digenic
-OMIM:619478	MONDO:0030355	facioscapulohumeral muscular dystrophy 4, digenic'		digenic
-OMIM:300818	MONDO:0010438	paroxysmal nocturnal hemoglobinuria 1		disease caused by a somatic mutation, therefore a gene association stating this is due to a germline mutation should not be added
+OMIM:603956	MONDO:0002974	cervical cancer'	https://orcid.org/0000-0002-4142-7153	evidence of various genes involved
+OMIM:619151	MONDO:0030894	"AMED syndrome, digenic'"	https://orcid.org/0000-0002-4142-7153	digenic
+OMIM:158901	MONDO:0008031		https://orcid.org/0000-0002-4142-7153	digenic
+OMIM:108770	MONDO:0007171	atrial standstill 1'	https://orcid.org/0000-0002-4142-7153	digenic
+OMIM:620040	MONDO:0031057	"dyskeratosis congenita, digenic'"	https://orcid.org/0000-0002-4142-7153	digenic
+OMIM:619478	MONDO:0030355	"facioscapulohumeral muscular dystrophy 4, digenic'"	https://orcid.org/0000-0002-4142-7153	digenic
+OMIM:300818	MONDO:0010438	paroxysmal nocturnal hemoglobinuria 1	https://orcid.org/0000-0002-4142-7153	"disease caused by a somatic mutation, therefore a gene association stating this is due to a germline mutation should not be added"

--- a/omim2obo/config.py
+++ b/omim2obo/config.py
@@ -9,6 +9,7 @@ ROOT_DIR = Path(__file__).resolve().parent.parent
 DATA_DIR = ROOT_DIR / 'data'
 ENV_PATH = ROOT_DIR / '.env'
 REVIEW_CASES_PATH = ROOT_DIR / 'review.tsv'
+DISEASE_GENE_EXCLUSIONS_PATH = DATA_DIR / 'exclusions-disease-gene.tsv'
 
 with open(DATA_DIR / 'dipper/GLOBAL_TERMS.yaml') as file:
     GLOBAL_TERMS = yaml.safe_load(file)

--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -132,20 +132,6 @@ def add_subclassof_restriction_with_evidence_and_source(
     # Add restriction on MIM class
     b: BNode = add_subclassof_restriction(graph, predicate, some_values_from, on)
     # Add axiom to restriction
-    # TODO temp: remove comments when verified in OFN that there is no diff
-    # b2 = BNode()
-    # graph.add((b2, RDF['type'], OWL['Axiom']))
-    # graph.add((b2, OWL['annotatedSource'], on))
-    # graph.add((b2, OWL['annotatedProperty'], RDFS['subClassOf']))
-    # graph.add((b2, OWL['annotatedTarget'], b))
-
-    #     axiom = BNode()
-    #     graph.add((axiom, RDF.type, OWL.Axiom))
-    #     graph.add((axiom, OWL.annotatedProperty, prop))
-    #     graph.add((axiom, OWL.annotatedTarget, target))
-
-    # graph.add((b2, BIOLINK['has_evidence'], evidence))
-    # graph.add((b2, RDFS['comment'], evidence))
     annotation_pred_vals = [
         (BIOLINK['has_evidence'], evidence),
         (RDFS['comment'], evidence)
@@ -394,11 +380,13 @@ def omim2obo(use_cache: bool = False):
             if not p_mim or p_map_key == '1':
                 continue
 
-            # Add restrictions: Gene->Disease non-causal (disease-defining) relationships
+            # Add restrictions: Gene->Disease non-causal / non-disease-defining relationships
             # - RO:0003302 docs: see MORBIDMAP_PHENOTYPE_MAPPING_KEY_PREDICATES
             # - Mapping key 3 = 'causal' (disease-defining). Handled separately below.
             if p_map_key != '3' or p_mim_excluded:
-                g2d_pred = MORBIDMAP_PHENOTYPE_MAPPING_KEY_PREDICATES[p_map_key] if len(assocs) == 1 else RO['0003302']
+                g2d_pred = MORBIDMAP_PHENOTYPE_MAPPING_KEY_PREDICATES[p_map_key] \
+                    if len(assocs) == 1 and not p_mim_excluded \
+                    else RO['0003302']
                 orcid: Optional[URIRef] = exclusions_p_mim_orcid_map[p_mim] if p_mim_excluded else None
                 add_subclassof_restriction_with_evidence_and_source(
                     graph, g2d_pred, OMIM[p_mim], OMIM[gene_mim], evidence, orcid)

--- a/omim2obo/namespaces.py
+++ b/omim2obo/namespaces.py
@@ -102,6 +102,7 @@ EOM_IMG = Namespace('https://elementsofmorphology.nih.gov/images/terms/')
 # publication/citation/reference sources
 DOI = Namespace('http://dx.doi.org/')                                         # Digital Object identifier
 GENEREVIEWS = Namespace('http://www.ncbi.nlm.nih.gov/books/')                 # NCBI gene and diseases
+ORCID = Namespace('https://orcid.org/')                                        # Open Researcher and Contributor ID
 # more bogus IRIs
 ISBN = Namespace('https://monarchinitiative.org/ISBN_')                       # International Standard Book Number
 ISBN_10 = Namespace('https://monarchinitiative.org/ISBN10_')                  # Same as ISBN has 10 digits pre 2007

--- a/omim2obo/utils/utils.py
+++ b/omim2obo/utils/utils.py
@@ -1,5 +1,10 @@
 """Misc utilities"""
-from typing import List, Union
+from typing import Dict, List, Optional, Union
+
+import pandas as pd
+
+from omim2obo.config import DISEASE_GENE_EXCLUSIONS_PATH
+from omim2obo.namespaces import ORCID
 
 
 # todo: also in mondo-ingest. Refactor into mondolib: https://github.com/monarch-initiative/mondolib/issues/13
@@ -14,3 +19,14 @@ def remove_angle_brackets(uris: Union[str, List[str]]) -> Union[str, List[str]]:
         x = x[:-1] if x.endswith('>') else x
         uris2.append(x)
     return uris2[0] if str_input else uris2
+
+
+def get_d2g_exclusions_by_curator(path=DISEASE_GENE_EXCLUSIONS_PATH) -> Dict[str, Optional[str]]:
+    """Get disease-gene exclusions
+
+    :return: Dict[str, str]: Phenotype MIM as keys, ORCID of curator as values
+    """
+    df = pd.read_csv(path, sep='\t').fillna('')
+    df['phenotype_mim'] = df['omim_id'].apply(lambda x: x.split(':')[1])
+    phenotype_mim_orcid_map = {x['phenotype_mim']: x['orcid'] for x in df.to_dict(orient='records')}
+    return {k: ORCID[v] if v else None for k, v in phenotype_mim_orcid_map.items()}

--- a/sparql/disease-gene-relationships.sparql
+++ b/sparql/disease-gene-relationships.sparql
@@ -24,6 +24,7 @@ WHERE {
 
   FILTER(
     ?PredUri IN (
+      <http://purl.obolibrary.org/obo/RO_0003302>,
       <http://purl.obolibrary.org/obo/RO_0003303>,
       <http://purl.obolibrary.org/obo/RO_0003304>,
       <http://purl.obolibrary.org/obo/RO_0004013>,


### PR DESCRIPTION
addresses #174

Added a way for us to manually make exclusions, such that entries in morbidmap.txt will not get populated as disease-genes associations.

## Changes
- Add: `data/exclusions-disease-gene.tsv`: Manually curated file.
- Update: Logic to utilize the above TSV.

## Additional info
- [Outputs & diffs on Google Drive](https://drive.google.com/drive/u/0/folders/1FcKvJBiZV5ZLHW9B_w2y6Dt8IHDkVNl8)
- [Updated Google Sheet](https://docs.google.com/spreadsheets/d/1-9V5nnsCc1rHXzzVrr9OuE9bTHTGYptT4QWP5kiTYRM/edit?gid=256856321#gid=256856321)