### PR TITLE
Bug fix: title symbol splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ allelicVariants.tsv
 
 # Outputs
 /*.json
+/*.obo
 /*.owl
 /*.tsv
 /*.ttl

--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -42,11 +42,12 @@ Steps
 - Parses mim2gene2.txt
   A tab-delimited file linking MIM numbers with NCBI Gene IDs, Ensembl Gene IDs, and HGNC Approved Gene Symbols.
   - Adds HGNC symbols
-- TODO: Parses hgnc/hgnc_complete_set.txt
-  A tab-delimited file with purpose unknown to me (Joe), but has mappings between HGNC symbols and IDs.
-  - Get HGNC symbol::id mappings.
-todo: The downloads should all happen at beginning of script
-todo: This is last updated 4/2022 and now does not fully describe everything that happens.
+- Parses: hgnc/hgnc_complete_set.txt: mappings between  HGNC symbols and IDs. Get HGNC symbol::id mappings.
+
+todo's
+ - Downloads should all happen at beginning of script
+ - This is last updated 4/2022 and now does not fully describe everything that happens.
+ - Codestyle: Namespace prop access should be consistenly NAMESPACE.prop or NAMESPACE['prop'] (choose one)
 
 Assumptions
 1. Mappings obtained from official OMIM files as described above are interpreted correctly (e.g. skos:exactMatch).

--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -230,7 +230,7 @@ def omim2obo(use_cache: bool = False):
         # - Non-deprecated
         # Parse titles & symbols
         omim_type, pref_titles_str, alt_titles_str, inc_titles_str = omim_type_and_titles[omim_id]
-        pref_titles_and_symbols: List[str] = [x.strip() for x in pref_titles_str.split(';')]
+        pref_titles_and_symbols: List[str] = [x.strip() for x in pref_titles_str.split('; ')]
         pref_title, pref_symbols = cleanup_title(pref_titles_and_symbols[0]), pref_titles_and_symbols[1:]
         alt_titles, alt_symbols, former_alt_titles, former_alt_symbols = \
             get_alt_and_included_titles_and_symbols(alt_titles_str)

--- a/omim2obo/parsers/omim_entry_parser.py
+++ b/omim2obo/parsers/omim_entry_parser.py
@@ -84,7 +84,7 @@ def transform_entry(entry) -> Graph:
 
     graph.add((omim_uri, RDF.type, OWL.Class))
 
-    abbrev = label.split(';')[1].strip() if ';' in label else None
+    abbrev = label.split('; ')[1].strip() if ';' in label else None
 
     if omim_type == OmimType.HERITABLE_PHENOTYPIC_MARKER.value:  # %
         graph.add((omim_uri, RDFS.label, Literal(cleanup_title(label))))
@@ -361,9 +361,9 @@ def parse_title_symbol_pairs(title_symbol_pairs_str: str) -> Tuple[List[str], Li
     """
     titles: List[str] = []
     symbols: List[str] = []
-    title_symbol_pairs: List[str] = title_symbol_pairs_str.split(';;')
+    title_symbol_pairs: List[str] = title_symbol_pairs_str.split(';; ')
     for pair_str in title_symbol_pairs:
-        pair: List[str] = [x.strip() for x in pair_str.split(';')]
+        pair: List[str] = [x.strip() for x in pair_str.split('; ')]
         titles.append(pair[0])
         symbols.extend(pair[1:])
     return titles, symbols


### PR DESCRIPTION
Partially addresses:
- Sub-task (3) in #191

## Summary of fix
Addressing issue where should have been including a space when splitting, e.g. '; ' and ';; '.

## Context
Basically, OMIM has title/symbol pairs in `mimTitles.txt`. The pairs are delimited by `;; `. And in each pair, the first entry is a title, with a `; ` after it if there are any associated symbols, with further `; ` delimiting each of those symbols.