### PR TITLE
Bug fix: protections: Remove old redundancy

### DIFF
--- a/omim2obo/mondo_omim_genes_robot_tsv.py
+++ b/omim2obo/mondo_omim_genes_robot_tsv.py
@@ -34,10 +34,6 @@ def mondo_omim_genes_robot_tsv(inpath: Union[Path, str], outpath: Union[Path, st
     # Sort
     df = df.sort_values(by=['mondo_id', 'hgnc_id', 'omim_gene', 'omim_disease_xref'])
 
-    # Remove cases where >1 gene association
-    # - These indicate non-causal relationships, which we don't care about.
-    df = df[~df['omim_disease_xref'].duplicated(keep=False)]
-
     # Insert ROBOT subheader
     df = pd.concat([pd.DataFrame([ROBOT_SUBHEADER]), df])
 


### PR DESCRIPTION
Delete: Some old code which ended up being a redundancy to filter out disease-gene associations with >1 association per phenotype. Rather than update this redundancy to also incorporate protections, the better, simpler route favoring stability would be to remove the redundancy.