### PR TITLE
Protect gene associations to immunoglobin gene/regions

### DIFF
--- a/data/protected-disease-gene.tsv
+++ b/data/protected-disease-gene.tsv
@@ -10,3 +10,4 @@ OMIM:620040	MONDO:0031057	"dyskeratosis congenita, digenic"	digenic	OMIM:607427	
 OMIM:619478	MONDO:0030355	"facioscapulohumeral muscular dystrophy 4, digenic"	digenic	OMIM:602900	HGNC:2979	https://orcid.org/0000-0002-4142-7153	
 OMIM:619478	MONDO:0030355	"facioscapulohumeral muscular dystrophy 4, digenic"	digenic	OMIM:606009	HGNC:50800	https://orcid.org/0000-0002-4142-7153	
 OMIM:614102	MONDO:0013576	"recurrent infections associated with rare immunoglobulin isotypes deficiency"	immunoglobin gene/regions	OMIM:147200	HGNC:5716	https://orcid.org/0000-0002-3458-4839	
+OMIM:615387	MONDO:0014160	"TCR-alpha-beta-positive T-cell deficiency"	immunoglobin gene/regions	OMIM:186880	HGNC:12029	https://orcid.org/0000-0002-3458-4839	

--- a/data/protected-disease-gene.tsv
+++ b/data/protected-disease-gene.tsv
@@ -9,5 +9,6 @@ OMIM:620040	MONDO:0031057	"dyskeratosis congenita, digenic"	digenic	OMIM:188350	
 OMIM:620040	MONDO:0031057	"dyskeratosis congenita, digenic"	digenic	OMIM:607427	HGNC:30365	https://orcid.org/0000-0002-4142-7153	
 OMIM:619478	MONDO:0030355	"facioscapulohumeral muscular dystrophy 4, digenic"	digenic	OMIM:602900	HGNC:2979	https://orcid.org/0000-0002-4142-7153	
 OMIM:619478	MONDO:0030355	"facioscapulohumeral muscular dystrophy 4, digenic"	digenic	OMIM:606009	HGNC:50800	https://orcid.org/0000-0002-4142-7153	
-OMIM:614102	MONDO:0013576	"recurrent infections associated with rare immunoglobulin isotypes deficiency"	immunoglobin gene/regions	OMIM:147200	HGNC:5716	https://orcid.org/0000-0002-3458-4839	
-OMIM:615387	MONDO:0014160	"TCR-alpha-beta-positive T-cell deficiency"	immunoglobin gene/regions	OMIM:186880	HGNC:12029	https://orcid.org/0000-0002-3458-4839	
+OMIM:614102	MONDO:0013576	"recurrent infections associated with rare immunoglobulin isotypes deficiency"	immunoglobin	OMIM:147200	HGNC:5716	https://orcid.org/0000-0002-3458-4839	
+OMIM:615387	MONDO:0014160	"TCR-alpha-beta-positive T-cell deficiency"	immunoglobin	OMIM:186880	HGNC:12029	https://orcid.org/0000-0002-3458-4839	
+OMIM:601495	MONDO:0020729	"autosomal recessive agammaglobulinemia 1"	immunoglobin	OMIM:147020	HGNC:5541	https://orcid.org/0000-0002-3458-4839	

--- a/data/protected-disease-gene.tsv
+++ b/data/protected-disease-gene.tsv
@@ -9,3 +9,4 @@ OMIM:620040	MONDO:0031057	"dyskeratosis congenita, digenic"	digenic	OMIM:188350	
 OMIM:620040	MONDO:0031057	"dyskeratosis congenita, digenic"	digenic	OMIM:607427	HGNC:30365	https://orcid.org/0000-0002-4142-7153	
 OMIM:619478	MONDO:0030355	"facioscapulohumeral muscular dystrophy 4, digenic"	digenic	OMIM:602900	HGNC:2979	https://orcid.org/0000-0002-4142-7153	
 OMIM:619478	MONDO:0030355	"facioscapulohumeral muscular dystrophy 4, digenic"	digenic	OMIM:606009	HGNC:50800	https://orcid.org/0000-0002-4142-7153	
+OMIM:614102	MONDO:0013576	"recurrent infections associated with rare immunoglobulin isotypes deficiency"	immunoglobin gene/regions	OMIM:147200	HGNC:5716	https://orcid.org/0000-0002-3458-4839	

--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -375,7 +375,7 @@ def omim2obo(use_cache: bool = False):
 
     # - Add relations (subclass restrictions)
     exclusions_p_mim_orcid_map: Dict[str, Optional[URIRef]] = get_d2g_exclusions_by_curator()
-    digenic_protection_gene_pheno_orcids: Dict[Tuple[str, str], Optional[URIRef]] = get_d2g_digenic_protections()
+    digenic_protection_gene_pheno_orcids: Dict[Tuple[str, str, str], Optional[URIRef]] = get_d2g_digenic_protections()
     for p_mim, assocs in phenotype_genes.items():
         for assoc in assocs:
             gene_mim, p_lab, p_map_key, p_map_lab = assoc['gene_id'], assoc['phenotype_label'], \
@@ -383,11 +383,19 @@ def omim2obo(use_cache: bool = False):
             evidence = f'Evidence: ({p_map_key}) {p_map_lab}'
             p_mim_excluded = p_mim in exclusions_p_mim_orcid_map
             protected_digenic_key = (p_mim, gene_mim)
-            protected_digenic_assoc: bool = protected_digenic_key in digenic_protection_gene_pheno_orcids
+            
+            # reduce key tuple back to only phenotype and gene mim identifiers to check for protected_digenic_key in protected-disease-gene.tsv 
+            reduced_map_digenic_protection_gene_pheno_orcids = {
+                (p_mim_protected, gene_mim_protected): (hgnc_id_protected, orcid_protected) for (p_mim_protected, gene_mim_protected, hgnc_id_protected), orcid_protected in digenic_protection_gene_pheno_orcids.items()
+            }
+            protected_digenic_assoc: bool = protected_digenic_key in reduced_map_digenic_protection_gene_pheno_orcids
 
             if protected_digenic_assoc:
-                orcid: Optional[URIRef] = digenic_protection_gene_pheno_orcids[protected_digenic_key]
-                add_gene_disease_associations(graph, gene_mim, p_mim, evidence, orcid)
+                hgnc_id_protected: str
+                orcid_protected: Optional[URIRef]
+                hgnc_id_protected, orcid_protected = reduced_map_digenic_protection_gene_pheno_orcids[protected_digenic_key]
+                add_gene_disease_associations(graph, gene_mim, p_mim, evidence, orcid_protected)
+                graph.add((OMIM[gene_mim], SKOS.exactMatch, HGNC[hgnc_id_protected]))
                 continue
 
             # Skip: No phenotype or unknown defect

--- a/omim2obo/main.py
+++ b/omim2obo/main.py
@@ -375,7 +375,8 @@ def omim2obo(use_cache: bool = False):
 
     # - Add relations (subclass restrictions)
     exclusions_p_mim_orcid_map: Dict[str, Optional[URIRef]] = get_d2g_exclusions_by_curator()
-    digenic_protection_gene_pheno_orcids: Dict[Tuple[str, str, str], Optional[URIRef]] = get_d2g_digenic_protections()
+    protections_gene_pheno__hgnc_orcid_map: Dict[Tuple[str, str], Tuple[str, Optional[URIRef]]] = \
+        get_d2g_digenic_protections()
     for p_mim, assocs in phenotype_genes.items():
         for assoc in assocs:
             gene_mim, p_lab, p_map_key, p_map_lab = assoc['gene_id'], assoc['phenotype_label'], \
@@ -383,17 +384,12 @@ def omim2obo(use_cache: bool = False):
             evidence = f'Evidence: ({p_map_key}) {p_map_lab}'
             p_mim_excluded = p_mim in exclusions_p_mim_orcid_map
             protected_digenic_key = (p_mim, gene_mim)
-            
-            # reduce key tuple back to only phenotype and gene mim identifiers to check for protected_digenic_key in protected-disease-gene.tsv 
-            reduced_map_digenic_protection_gene_pheno_orcids = {
-                (p_mim_protected, gene_mim_protected): (hgnc_id_protected, orcid_protected) for (p_mim_protected, gene_mim_protected, hgnc_id_protected), orcid_protected in digenic_protection_gene_pheno_orcids.items()
-            }
-            protected_digenic_assoc: bool = protected_digenic_key in reduced_map_digenic_protection_gene_pheno_orcids
 
+            protected_digenic_assoc: bool = protected_digenic_key in protections_gene_pheno__hgnc_orcid_map
             if protected_digenic_assoc:
                 hgnc_id_protected: str
                 orcid_protected: Optional[URIRef]
-                hgnc_id_protected, orcid_protected = reduced_map_digenic_protection_gene_pheno_orcids[protected_digenic_key]
+                hgnc_id_protected, orcid_protected = protections_gene_pheno__hgnc_orcid_map[protected_digenic_key]
                 add_gene_disease_associations(graph, gene_mim, p_mim, evidence, orcid_protected)
                 graph.add((OMIM[gene_mim], SKOS.exactMatch, HGNC[hgnc_id_protected]))
                 continue

--- a/omim2obo/utils/utils.py
+++ b/omim2obo/utils/utils.py
@@ -30,10 +30,10 @@ def get_d2g_digenic_protections(path=DISEASE_GENE_PROTECTED_PATH) -> Dict[Tuple[
     :return: Dictionary with phenotype and gene MIMs as keys and ORCID of curator as values.
     """
     df = pd.read_csv(path, sep='\t').fillna('')
-    for col in ['phenotype_mim', 'gene_mim']:
+    for col in ['phenotype_mim', 'gene_mim', 'hgnc_id']:
         df[col] = df[col].apply(lambda x: x.split(':')[1])
     return {
-        (x['phenotype_mim'], x['gene_mim']): ORCID[x['orcid']] if x['orcid'] else None
+        (x['phenotype_mim'], x['gene_mim'], x['hgnc_id']): ORCID[x['orcid']] if x['orcid'] else None
         for x in df.to_dict(orient='records')
     }
 

--- a/omim2obo/utils/utils.py
+++ b/omim2obo/utils/utils.py
@@ -22,18 +22,20 @@ def remove_angle_brackets(uris: Union[str, List[str]]) -> Union[str, List[str]]:
     return uris2[0] if str_input else uris2
 
 
-def get_d2g_digenic_protections(path=DISEASE_GENE_PROTECTED_PATH) -> Dict[Tuple[str, str], Optional[URIRef]]:
+def get_d2g_digenic_protections(
+    path=DISEASE_GENE_PROTECTED_PATH
+) -> Dict[Tuple[str, str], Tuple[str, Optional[URIRef]]]:
     """Get information for manually curated disease-gene association protections.
 
     Protections are associatiosn we want to add even if they (no longer) appear in the OMIM source data.
 
-    :return: Dictionary with phenotype and gene MIMs as keys and ORCID of curator as values.
+    :return: Dictionary with (phenotype MIM, gene MIM) keys and (HGNC id, curator ORCID) values.
     """
     df = pd.read_csv(path, sep='\t').fillna('')
     for col in ['phenotype_mim', 'gene_mim', 'hgnc_id']:
         df[col] = df[col].apply(lambda x: x.split(':')[1])
     return {
-        (x['phenotype_mim'], x['gene_mim'], x['hgnc_id']): ORCID[x['orcid']] if x['orcid'] else None
+        (x['phenotype_mim'], x['gene_mim']): (x['hgnc_id'], ORCID[x['orcid']] if x['orcid'] else None)
         for x in df.to_dict(orient='records')
     }
 


### PR DESCRIPTION
closes https://github.com/monarch-initiative/omim/issues/205

Updating the file in order to "protect" and maintain the gene associations to immunoglobin gene/regions where there is a HGNC identifier for the immunoglobin gene/region despite there not being a HGNC identifier in the mim2gene.txt file.