### PR TITLE
Update protected-disease-gene.tsv

### DIFF
--- a/data/protected-disease-gene.tsv
+++ b/data/protected-disease-gene.tsv
@@ -12,3 +12,4 @@ OMIM:619478	MONDO:0030355	"facioscapulohumeral muscular dystrophy 4, digenic"	di
 OMIM:614102	MONDO:0013576	"recurrent infections associated with rare immunoglobulin isotypes deficiency"	immunoglobin	OMIM:147200	HGNC:5716	https://orcid.org/0000-0002-3458-4839	
 OMIM:615387	MONDO:0014160	"TCR-alpha-beta-positive T-cell deficiency"	immunoglobin	OMIM:186880	HGNC:12029	https://orcid.org/0000-0002-3458-4839	
 OMIM:601495	MONDO:0020729	"autosomal recessive agammaglobulinemia 1"	immunoglobin	OMIM:147020	HGNC:5541	https://orcid.org/0000-0002-3458-4839	
+OMIM:219700	MONDO:0009061	"cystic fibrosis"	confirmed	OMIM:602421	HGNC:1884	https://orcid.org/0000-0002-4142-7153	


### PR DESCRIPTION
I added OMIM:219700 for gene association to keep, even though it does not follow our rules.  The "type" does not exist yet. 
Basically, in omim, the disease itself is associated to the gene in this list. The other associated genes in OMIM are for susceptibility to or modifier of the disease.