### PR TITLE
Updated "protected" entry

### DIFF
--- a/data/protected-disease-gene.tsv
+++ b/data/protected-disease-gene.tsv
@@ -58,3 +58,10 @@ OMIM:620500	MONDO:0957594	"spermatogenic failure 87"	provisional	OMIM:102480	HGN
 OMIM:620849	MONDO:0971000	"spermatogenic failure 93"	provisional	OMIM:607670	HGNC:14568	https://orcid.org/0000-0002-7638-4659	
 OMIM:621057	MONDO:0975958	"spermatogenic failure 97"	provisional	OMIM:621033	HGNC:29915	https://orcid.org/0000-0002-7638-4659	
 OMIM:301106	MONDO:0957202	"spermatogenic failure, X-linked, 7"	provisional	OMIM:301105	HGNC:26047	https://orcid.org/0000-0002-7638-4659	
+OMIM:245570	MONDO:0009509	"Landau-Kleffner syndrome"	included entry	OMIM:138253	HGNC:4585	https://orcid.org/0000-0002-4142-7153	
+OMIM:611465	MONDO:1010151	"gallbladder disease 4"	susceptibility	OMIM:605460	HGNC:13887	https://orcid.org/0000-0002-4142-7153	
+OMIM:613765	MONDO:0013412	"hypertrophic cardiomyopathy 9"	provisional	OMIM:188840	HGNC:12403	https://orcid.org/0000-0002-4142-7153	
+OMIM:615988	MONDO:0014439	"Bardet-Biedl syndrome 11"	provisional	OMIM:602290	HGNC:16380	https://orcid.org/0000-0002-4142-7153	
+OMIM:500014	MONDO:0027068	"mitochondrial complex I deficiency, mitochondrial type 1"	confirmed	OMIM:516002		https://orcid.org/0000-0002-4142-7153	
+OMIM:619059	MONDO:0033650	"mitochondrial complex IV deficiency, nuclear type 15"	provisional	OMIM:123870	HGNC:2294	https://orcid.org/0000-0002-4142-7153	
+OMIM:147430	MONDO:0958106	"congenital insensitivity to pain syndrome, Marsili type"	provisional	OMIM:617828	HGNC:20152	https://orcid.org/0000-0002-4142-7153	


### PR DESCRIPTION
@twhetzel please note the line for OMIM:500014:

The OMIM gene is https://www.omim.org/entry/516002, however, the corresponding HGNC term does not exist: https://www.genenames.org/tools/search/#!/genes?query=MT-ND3 I left the HGNC field empty, but I don't know that it was the best way to handle this situation.