### PR TITLE
remove entry with no gene mim

### DIFF
--- a/data/protected-disease-gene.tsv
+++ b/data/protected-disease-gene.tsv
@@ -381,7 +381,6 @@ OMIM:610024	MONDO:0012398	"retinal cone dystrophy 3A"	manually reviewed	OMIM:601
 OMIM:610100	MONDO:0012411	"giant axonal neuropathy 2"	manually reviewed	OMIM:615820	HGNC:24891	https://orcid.org/0000-0002-4142-7153	
 OMIM:610125	MONDO:0012413	"syndromic microphthalmia type 5"	manually reviewed	OMIM:600037	HGNC:8522	https://orcid.org/0000-0002-4142-7153	
 OMIM:610125	MONDO:0012413	"syndromic microphthalmia type 5"	manually reviewed	OMIM:600037	HGNC:8522	https://orcid.org/0000-0002-4142-7153	
-OMIM:610149	MONDO:0012419	"age related macular degeneration 7"	manually reviewed	#N/A	HGNC:9476	https://orcid.org/0000-0002-4142-7153	
 OMIM:610154	MONDO:0012421	"autosomal recessive nonsyndromic hearing loss 44"	manually reviewed	OMIM:103072	HGNC:232	https://orcid.org/0000-0002-4142-7153	
 OMIM:610163	MONDO:0012426	"immunodeficiency 25"	manually reviewed	OMIM:186780	HGNC:1677	https://orcid.org/0000-0002-4142-7153	
 OMIM:610204	MONDO:0012438	"pontocerebellar hypoplasia type 5"	manually reviewed	OMIM:608755	HGNC:27561	https://orcid.org/0000-0002-4142-7153	


### PR DESCRIPTION
The OMIM entry does not a gene MIM for this entry https://omim.org/entry/610149 since it's marked as the molecular basis is unknown. I was added in a PR [here](https://github.com/monarch-initiative/omim/pull/276/files#diff-261066b07106a3db627bd3a89f5a2a068e3f5af7542e72d04c20bdc978c2b60eR377) as part of the "Add 600+ new protected associations from the original mim2gene" PR. 