### PR TITLE
Add six new disease-gene associations to protected-disease-gene.tsv,

### DIFF
--- a/data/protected-disease-gene.tsv
+++ b/data/protected-disease-gene.tsv
@@ -569,3 +569,9 @@ OMIM:611465	MONDO:1010151	"gallbladder disease 4"	manually reviewed	OMIM:605460	
 OMIM:193670	MONDO:8000006	"WHIM syndrome 1"	manually reviewed	OMIM:162643	HGNC:2561	https://orcid.org/0000-0002-4142-7153	
 OMIM:617925	MONDO:0044328	"short-rib thoracic dysplasia 20 with polydactyly"	provisional	OMIM:610621	HGNC:29239	https://orcid.org/0000-0002-7638-4659	
 OMIM:610149	MONDO:0012419	"age related macular degeneration 7"	manually reviewed	OMIM:602194	HGNC:9476	https://orcid.org/0000-0002-4142-7153	
+OMIM:200950	MONDO:0008705	"lysosomal acid phosphatase deficiency"	manually reviewed	OMIM:171650	HGNC:123	https://orcid.org/0000-0002-4142-7153	
+OMIM:256550	MONDO:0009738	"sialidosis type 2"	manually reviewed	OMIM:608272	HGNC:7758	https://orcid.org/0000-0002-4142-7153	
+OMIM:264080	MONDO:0009909	"progesterone resistance"	manually reviewed	OMIM:607311	HGNC:8910	https://orcid.org/0000-0002-4142-7153	
+OMIM:614033	MONDO:0013535	"hydroxyacyl glutathione hydrolase deficiency"	manually reviewed	OMIM:138760	HGNC:4805	https://orcid.org/0000-0002-4142-7153	
+OMIM:614037	MONDO:0013539	"hypotonia-failure to thrive-microcephaly syndrome"	manually reviewed	OMIM:246530	HGNC:6719	https://orcid.org/0000-0002-4142-7153	
+OMIM:614055	MONDO:0013548	"acetyl-CoA acetyltransferase-2 deficiency"	manually reviewed	OMIM:100678	HGNC:94	https://orcid.org/0000-0002-4142-7153	


### PR DESCRIPTION
Appended six manually reviewed entries to protected-disease-gene.tsv, including lysosomal acid phosphatase deficiency, sialidosis type 2, progesterone resistance, hydroxyacyl glutathione hydrolase deficiency, hypotonia-failure to thrive-microcephaly syndrome, and acetyl-CoA acetyltransferase-2 deficiency.

These annotations came from work done in [this issue](https://github.com/monarch-initiative/mondo/issues/9602)